### PR TITLE
Implement ability to create an 'undo' of an action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-suite",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Store implementation for functional reactive flux.",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/satcheljs/lib/createUndo.ts
+++ b/packages/satcheljs/lib/createUndo.ts
@@ -1,0 +1,186 @@
+import { spy } from 'mobx';
+import satcheljsAction from './action';
+
+let spyRefCount = 0;
+let spyDisposer = null;
+
+function initializeSpy() {
+    if (spyRefCount === 0) {
+        spyDisposer = spy(spyOnChanges);
+    }
+    spyRefCount++;
+}
+
+function disposeSpy() {
+    spyRefCount--;
+    if (spyRefCount === 0) {
+        spyDisposer();
+        spyDisposer = null;
+    }
+}
+
+interface UndoStep {
+    verify: () => boolean;
+    objectName: string;
+    propertyName: string;
+    undo: () => void;
+}
+
+interface UndoWindow {
+    steps: UndoStep[];
+}
+
+// We may have nested "undo" actions, so we need to track those windows separately
+let undoWindows: UndoWindow[] = [];
+
+function spyOnChanges(event) {
+    let undoStep: UndoStep;
+    let { modifiedObject } = event;
+
+    switch(event.type) {
+        case 'update':
+            if (event.index !== undefined) {
+                // update (array)
+                undoStep = {
+                    verify: () => modifiedObject[event.index] === event.newValue,
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.index,
+                    undo: () => { modifiedObject[event.index] = event.oldValue; }
+                };
+            } else if (typeof modifiedObject.get !== 'undefined') {
+                // update (map)
+                undoStep = {
+                    verify: () => modifiedObject.get(event.name) === event.newValue,
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.name,
+                    undo: () => { modifiedObject.set(event.name, event.oldValue); }
+                };
+            } else {
+                // update (object)
+                undoStep = {
+                    verify: () => modifiedObject[event.name] === event.newValue,
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.name,
+                    undo: () => { modifiedObject[event.name] = event.oldValue); }
+                };
+            }
+            break;
+        case 'splice':
+            undoStep = {
+                verify: () => {
+                    for (let i = 0; i < event.addedCount; i++) {
+                        if (modifiedObject[event.index + i] !== event.added[i]) {
+                            return false;
+                        }
+                    }
+                    return true;
+                },
+                objectName: modifiedObject.$mobx.name,
+                propertyName: event.index,
+                undo: () => {
+                    // First, remove the added items.
+                    // Then, add items back one at a time, because passing an array in to 'splice' will insert the array as a single item
+                    modifiedObject.splice(event.index, event.addedCount);
+                    for (let i = 0; i < event.removedCount; i++) {
+                        modifiedObject.splice(event.index + i, 0, event.removed[i]);
+                    }
+                }
+            };
+            break;
+        case 'add':
+            if (typeof modifiedObject.get !== 'undefined') {
+                // add (map)
+                undoStep = {
+                    verify: () => modifiedObject.get(event.name) === event.newValue,
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.name,
+                    undo: () => { modifiedObject.delete(event.name); }
+                }
+            } else {
+                // add (object)
+                undoStep = {
+                    verify: () => modifiedObject[event.name] === event.newValue,
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.name,
+                    undo: () => { delete modifiedObject[event.name]; }
+                }
+            }
+            break;
+        case 'delete':
+            undoStep = {
+                verify: () => !modifiedObject.has(event.name),
+                    objectName: modifiedObject.$mobx.name,
+                    propertyName: event.name,
+                    undo: () => { modifiedObject[event.name] = event.oldValue; }
+            }
+            break;
+        default:
+            // Nothing worth tracking
+            return;
+    }
+
+    undoWindows.forEach(window => window.steps.push(undoStep));
+}
+
+export interface UndoResult<T> {
+    actionReturnValue: T;
+    undo: () => void;
+}
+
+export type CreateUndoReturnValue<T> = (action: () => T) => UndoResult<T>;
+
+function trackUndo<T>(
+    actionName: string,
+    action: () => T,
+    undoVerifiesChanges: boolean) : UndoResult<T> {
+
+        initializeSpy();
+        undoWindows.push({steps: []});
+
+        try {
+            let returnValue: T = action();
+
+            let window : UndoWindow = undoWindows[undoWindows.length - 1];
+
+            // Reverse the steps, as changes made later in the action may depend on changes earlier in the action
+            window.steps.reverse();
+
+            let undo = satcheljsAction(`undo-${actionName}`)(() => {
+                if (undoVerifiesChanges) {
+                    window.steps.forEach(step => {
+                        if (!step.verify()) {
+                            throw `Property "${step.propertyName} on store object "${step.objectName} changed since action was performed.`
+                        }
+                    })
+                }
+                window.steps.forEach(step => step.undo());
+            });
+
+            return {
+                actionReturnValue: returnValue,
+                undo: undo,
+            }
+        } finally {
+            undoWindows.pop();
+            disposeSpy();
+        }
+}
+
+/**
+ * Creates a method to undo all store changes done by a supplied action
+ * @param {string} actionName is the name of the action being tracked. The returned undo action will be given the name undo-<actionName>.
+ * @param {boolean} undoVerifiesChanges indicates whether the returned undo action will verify no subsequent changes have been made to
+ *      objects being tracked since the original action has been performed. If true and changes have since been made to modified objects,
+ *      the undo action will not make any changes and will throw an exception.
+ */
+export default function createUndo<T>(
+    actionName: string,
+    undoVerifiesChanges?: boolean) : CreateUndoReturnValue<T> {
+
+        return (action: () => T) => {
+            return trackUndo(
+                    actionName,
+                    action,
+                    !!undoVerifiesChanges);
+        };
+}

--- a/packages/satcheljs/lib/createUndo.ts
+++ b/packages/satcheljs/lib/createUndo.ts
@@ -1,8 +1,8 @@
-import { spy } from 'mobx';
+import { Lambda, spy } from 'mobx';
 import satcheljsAction from './action';
 
 let spyRefCount = 0;
-let spyDisposer = null;
+let spyDisposer: Lambda = null;
 
 function initializeSpy() {
     if (spyRefCount === 0) {
@@ -33,9 +33,9 @@ interface UndoWindow {
 // We may have nested "undo" actions, so we need to track those windows separately
 let undoWindows: UndoWindow[] = [];
 
-function spyOnChanges(event) {
+function spyOnChanges(event: any) {
     let undoStep: UndoStep;
-    let { modifiedObject } = event;
+    let modifiedObject = event.object;
 
     switch(event.type) {
         case 'update':
@@ -61,7 +61,7 @@ function spyOnChanges(event) {
                     verify: () => modifiedObject[event.name] === event.newValue,
                     objectName: modifiedObject.$mobx.name,
                     propertyName: event.name,
-                    undo: () => { modifiedObject[event.name] = event.oldValue); }
+                    undo: () => { modifiedObject[event.name] = event.oldValue; }
                 };
             }
             break;
@@ -111,7 +111,7 @@ function spyOnChanges(event) {
                 verify: () => !modifiedObject.has(event.name),
                     objectName: modifiedObject.$mobx.name,
                     propertyName: event.name,
-                    undo: () => { modifiedObject[event.name] = event.oldValue; }
+                    undo: () => { modifiedObject.set(event.name, event.oldValue); }
             }
             break;
         default:
@@ -127,7 +127,7 @@ export interface UndoResult<T> {
     undo: () => void;
 }
 
-export type CreateUndoReturnValue<T> = (action: () => T) => UndoResult<T>;
+export type CreateUndoReturnValue<T> = (action: () => T | void) => UndoResult<T>;
 
 function trackUndo<T>(
     actionName: string,

--- a/packages/satcheljs/lib/createUndo.ts
+++ b/packages/satcheljs/lib/createUndo.ts
@@ -123,8 +123,8 @@ function spyOnChanges(event: any) {
 }
 
 export interface UndoResult<T> {
-    actionReturnValue: T;
-    undo: () => void;
+    actionReturnValue?: T;
+    (): void;
 }
 
 export type CreateUndoReturnValue<T> = (action: () => T | void) => UndoResult<T>;
@@ -145,7 +145,7 @@ function trackUndo<T>(
             // Reverse the steps, as changes made later in the action may depend on changes earlier in the action
             window.steps.reverse();
 
-            let undo = satcheljsAction(`undo-${actionName}`)(() => {
+            let undo: UndoResult<T> = satcheljsAction(`undo-${actionName}`)(() => {
                 if (undoVerifiesChanges) {
                     window.steps.forEach(step => {
                         if (!step.verify()) {
@@ -156,10 +156,9 @@ function trackUndo<T>(
                 window.steps.forEach(step => step.undo());
             });
 
-            return {
-                actionReturnValue: returnValue,
-                undo: undo,
-            }
+            undo.actionReturnValue = returnValue;
+
+            return undo;
         } finally {
             undoWindows.pop();
             disposeSpy();

--- a/packages/satcheljs/lib/index.ts
+++ b/packages/satcheljs/lib/index.ts
@@ -8,4 +8,5 @@ export { default as DispatchFunction } from './DispatchFunction';
 export { default as createStore } from './createStore';
 export { default as action } from './action';
 export { default as select, SelectorFunction } from './select';
+export { default as createUndo, UndoResult, CreateUndoReturnValue} from './createUndo';
 export { initializeTestMode, resetTestMode } from './testMode';

--- a/packages/satcheljs/test/createUndoTests.ts
+++ b/packages/satcheljs/test/createUndoTests.ts
@@ -367,4 +367,15 @@ describe('createUndo', () => {
 
         expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
     });
+
+    it('throws if an undo instance is called twice', () => {
+
+        let object = map({key: 2});
+        let undoableAction = action('updateMap')(() => { object.set('key', 5) });
+
+        let undoResult = createUndo('updateMap')(undoableAction);
+        undoResult();
+
+        expect(undoResult).toThrow();
+    });
 });

--- a/packages/satcheljs/test/createUndoTests.ts
+++ b/packages/satcheljs/test/createUndoTests.ts
@@ -378,4 +378,33 @@ describe('createUndo', () => {
 
         expect(undoResult).toThrow();
     });
+
+    it('handles nested undo windows called out of order', () => {
+        let array = observable([1, 2, 3, 4, 5]);
+
+        let innerUndo;
+        let outerUndo = createUndo('outerUndo')(action('outerUndo')(() => {
+            array[0] = 0;
+
+            expect(array.slice(0)).toEqual([0, 2, 3, 4, 5]);
+
+            innerUndo = createUndo('innerUndo')(action('innerUndo')(() => {
+                array[1] = 0;
+            }));
+
+            array[2] = 0;
+
+            expect(array.slice(0)).toEqual([0, 0, 0, 4, 5]);
+
+        }));
+
+        outerUndo();
+
+        expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
+
+        innerUndo();
+
+        expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
+
+    });
 });

--- a/packages/satcheljs/test/createUndoTests.ts
+++ b/packages/satcheljs/test/createUndoTests.ts
@@ -341,4 +341,30 @@ describe('createUndo', () => {
             expect(undoResult).toThrow();
         });
     });
+
+    it('handles nested undo windows', () => {
+        let array = observable([1, 2, 3, 4, 5]);
+
+        let outerUndo = createUndo('outerUndo')(action('outerUndo')(() => {
+            array[0] = 0;
+
+            expect(array.slice(0)).toEqual([0, 2, 3, 4, 5]);
+
+            let innerUndo = createUndo('innerUndo')(action('innerUndo')(() => {
+                array[1] = 0;
+            }));
+
+            array[2] = 0;
+
+            expect(array.slice(0)).toEqual([0, 0, 0, 4, 5]);
+
+            innerUndo();
+
+            expect(array.slice(0)).toEqual([0, 2, 0, 4, 5]);
+        }));
+
+        outerUndo();
+
+        expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
+    });
 });

--- a/packages/satcheljs/test/createUndoTests.ts
+++ b/packages/satcheljs/test/createUndoTests.ts
@@ -31,7 +31,7 @@ describe('createUndo', () => {
 
             expect(array[index]).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(array[index]).toBe(oldValue);
         });
@@ -48,7 +48,7 @@ describe('createUndo', () => {
 
             expect(object.get(index)).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.get(index)).toBe(oldValue);
         });
@@ -64,7 +64,7 @@ describe('createUndo', () => {
 
             expect(object.key).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.key).toBe(oldValue);
         });
@@ -77,7 +77,7 @@ describe('createUndo', () => {
 
             expect(object.slice(0)).toEqual([1, 2, 'a', 6]);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.slice(0)).toEqual([1, 2, 3, 4, 5, 6]);
         });
@@ -93,7 +93,7 @@ describe('createUndo', () => {
 
             expect(object.get(index)).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.has(index)).toBeFalsy;
         });
@@ -109,7 +109,7 @@ describe('createUndo', () => {
 
             expect(object[index]).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(Object.getOwnPropertyNames(object)).not.toContain(index);
         });
@@ -125,7 +125,7 @@ describe('createUndo', () => {
 
             expect(object.has(index)).toBeFalsy;
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.get(index)).toBe(oldValue);
         });
@@ -147,7 +147,7 @@ describe('createUndo', () => {
 
             expect(array[index]).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(array[index]).toBe(oldValue);
         });
@@ -164,7 +164,7 @@ describe('createUndo', () => {
 
             expect(object.get(index)).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.get(index)).toBe(oldValue);
         });
@@ -180,7 +180,7 @@ describe('createUndo', () => {
 
             expect(object.key).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.key).toBe(oldValue);
         });
@@ -193,7 +193,7 @@ describe('createUndo', () => {
 
             expect(object.slice(0)).toEqual([1, 2, 'a', 6]);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.slice(0)).toEqual([1, 2, 3, 4, 5, 6]);
         });
@@ -209,7 +209,7 @@ describe('createUndo', () => {
 
             expect(object.get(index)).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.has(index)).toBeFalsy;
         });
@@ -225,7 +225,7 @@ describe('createUndo', () => {
 
             expect(object[index]).toBe(newValue);
 
-            undoResult.undo();
+            undoResult();
 
             expect(Object.getOwnPropertyNames(object)).not.toContain(index);
         });
@@ -241,7 +241,7 @@ describe('createUndo', () => {
 
             expect(object.has(index)).toBeFalsy;
 
-            undoResult.undo();
+            undoResult();
 
             expect(object.get(index)).toBe(oldValue);
         });
@@ -262,7 +262,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('updateArray', true)(undoableAction);
             action('updateArray-again')(() => { array[index] = 100 })();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes an update to a map', () => {
@@ -276,7 +276,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('updateMap', true)(undoableAction);
             action('updateMap-again')(() => { object.set(index, 100) })();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes an update to an object', () => {
@@ -289,7 +289,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('updateObject', true)(undoableAction);
             action('updateObject-again')(() => { object.key = 100 })();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes an array splice', () => {
@@ -299,7 +299,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('spliceArray', true)(undoableAction);
             action('spliceArray-again')(() => { object[2] = 100 })();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes an add to a map', () => {
@@ -312,7 +312,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('addMap', true)(undoableAction);
             action('addMap-again')(() => {object.set(index, 100);})();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes an add to an object', () => {
@@ -325,7 +325,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('addObject', true)(undoableAction);
             action('addMap-again')(() => {object[index] = 100;})();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
 
         it('throws an exception when it undoes a delete to a map', () => {
@@ -338,7 +338,7 @@ describe('createUndo', () => {
             let undoResult = createUndo('deleteMap', true)(undoableAction);
             action('deleteMap-again')(() => {object.set(index, 100);})();
 
-            expect(undoResult.undo).toThrow();
+            expect(undoResult).toThrow();
         });
     });
 });

--- a/packages/satcheljs/test/dispatchTests.ts
+++ b/packages/satcheljs/test/dispatchTests.ts
@@ -5,6 +5,7 @@ import rootStore from '../lib/rootStore';
 import initializeState from '../lib/initializeState';
 import dispatch from '../lib/dispatch';
 import * as applyMiddlewareImports from '../lib/applyMiddleware';
+import { __resetGlobalContext } from '../lib/globalContext'
 
 var backupConsoleError = console.error;
 
@@ -12,6 +13,7 @@ describe("dispatch", () => {
     beforeEach(() => {
         _.resetGlobalState();
         initializeState({});
+        __resetGlobalContext();
     });
 
     beforeAll(() => {


### PR DESCRIPTION
This change implements `createUndo`, a way to create a callback that will rollback all changes made to the store within a supplied (and immediately invoked) callback. It optionally also verifies that no additional changes have been made to the changed properties since the initial action before rolling back the changes.