### PR TITLE
Allow @action decorator on class methods

### DIFF
--- a/packages/satcheljs/test/actionTests.ts
+++ b/packages/satcheljs/test/actionTests.ts
@@ -1,6 +1,7 @@
 import 'jasmine';
 import action from '../lib/action';
 import * as dispatchImports from '../lib/dispatch';
+import { getGlobalContext } from '../lib/globalContext';
 
 describe("action", () => {
     it("wraps the function call in a dispatch", () => {
@@ -48,5 +49,22 @@ describe("action", () => {
         let returnValue = testFunction();
 
         expect(returnValue).toBe(originalReturnValue);
+    });
+
+    it("can decorate a class method", () => {
+        let thisValue, inDispatchValue;
+        class TestClass {
+            @action("testMethod")
+            testMethod() {
+                thisValue = this;
+                inDispatchValue = getGlobalContext().inDispatch;
+            }
+        }
+
+        let testInstance = new TestClass();
+        testInstance.testMethod();
+
+        expect(thisValue).toBe(testInstance);
+        expect(inDispatchValue).toBe(1);
     });
 });

--- a/packages/satcheljs/tsconfig.json
+++ b/packages/satcheljs/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "removeComments": false,
     "noImplicitAny": true,
+    "experimentalDecorators": true,
     "baseUrl": "../../",
     "paths": {
       "*": [


### PR DESCRIPTION
This fixes #38; @action can now be used as a decorator on class methods.  Of course it still works the same way when wrapping a simple function.