### PR TITLE
Expose `actionType` on the wrapped action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-suite",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Store implementation for functional reactive flux.",
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/satcheljs-react-devtools/package.json
+++ b/packages/satcheljs-react-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-react-devtools",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "Dev tooling for React apps using SatchelJS.",
   "main": "./lib/index.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "react": "^15.4.0",
     "react-addons-perf": "^15.4.0",
     "react-dom": "^15.4.0",
-    "satcheljs": "2.8.2"
+    "satcheljs": "2.11.0"
   },
   "devDependencies": {
     "jasmine": "~2.4.1",

--- a/packages/satcheljs-react/package.json
+++ b/packages/satcheljs-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-react",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "SatchelJS hooks for React applications.",
   "main": "./lib/index.js",
   "scripts": {
@@ -15,7 +15,7 @@
     "mobx": "~2.6.5",
     "mobx-react": "~4.0.3",
     "react": "^15.4.0",
-    "satcheljs": "2.8.2"
+    "satcheljs": "2.11.0"
   },
   "devDependencies": {
     "jasmine": "~2.4.1",

--- a/packages/satcheljs-snapshots/package.json
+++ b/packages/satcheljs-snapshots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-snapshots",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "Adds snapshotting capability to SatchelJS",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "mobx": "~2.6.5",
-    "satcheljs": "2.8.2"
+    "satcheljs": "2.11.0"
   },
   "devDependencies": {
     "jasmine": "^2.4.1",

--- a/packages/satcheljs-stitch/package.json
+++ b/packages/satcheljs-stitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-stitch",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "Event aggregation middleware for SatchelJS.",
   "main": "./lib/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",
   "dependencies": {
-    "satcheljs": "2.8.2"
+    "satcheljs": "2.11.0"
   },
   "devDependencies": {
     "jasmine": "~2.4.1",

--- a/packages/satcheljs-trace/package.json
+++ b/packages/satcheljs-trace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs-trace",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "Tracing middleware for SatchelJS.",
   "main": "./lib/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",
   "dependencies": {
-    "satcheljs": "2.8.2"
+    "satcheljs": "2.11.0"
   },
   "devDependencies": {
     "jasmine": "~2.4.1",

--- a/packages/satcheljs/lib/action.ts
+++ b/packages/satcheljs/lib/action.ts
@@ -6,8 +6,12 @@ export interface RawAction {
     (... args: any[]): Promise<any> | void;
 }
 
+export interface Action {
+    actionType?: string;
+}
+
 export interface ActionFactory {
-    <T extends RawAction>(target: T): T;
+    <T extends RawAction>(target: T): T & Action;
     <T extends RawAction>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): void;
 }
 
@@ -21,8 +25,8 @@ export default function action(actionType: string, actionContext?: ActionContext
     } as ActionFactory;
 }
 
-function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string, actionContext: ActionContext): T {
-    let decoratedTarget = <T>function() {
+function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string, actionContext: ActionContext): T & Action {
+    let decoratedTarget: T & Action = <T>function() {
         let returnValue: any;
         let passedArguments = arguments;
 
@@ -34,6 +38,7 @@ function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string
 
         return returnValue;
     };
+    decoratedTarget.actionType = actionType;
 
     setOriginalTarget(decoratedTarget, target);
 

--- a/packages/satcheljs/package.json
+++ b/packages/satcheljs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satcheljs",
-  "version": "2.8.2",
+  "version": "2.11.0",
   "description": "Store implementation for functional reactive flux.",
   "main": "./lib/index.js",
   "scripts": {

--- a/packages/satcheljs/test/actionTests.ts
+++ b/packages/satcheljs/test/actionTests.ts
@@ -24,6 +24,15 @@ describe("action", () => {
         expect((<jasmine.Spy>dispatchImports.default).calls.argsFor(0)[2][0]).toBe("testArgument");
     });
 
+    it("sets the actionType as a property on the wrapped action", () => {
+        let testFunction = () => {};
+        let actionType = "testFunction";
+
+        let wrappedAction = action(actionType)(testFunction);
+
+        expect(wrappedAction.actionType).toBe(actionType)
+    });
+
     it("passes on the original arguments", () => {
         let passedArguments: IArguments;
 
@@ -66,5 +75,19 @@ describe("action", () => {
 
         expect(thisValue).toBe(testInstance);
         expect(inDispatchValue).toBe(1);
+    });
+
+    it("sets the actionType as a property on the wrapped class method", () => {
+        let actionType = "testFunction";
+
+        class TestClass {
+            @action(actionType)
+            testMethod() {
+            }
+        }
+
+        let testInstance = new TestClass();
+
+        expect((testInstance.testMethod as any).actionType).toBe(actionType);
     });
 });


### PR DESCRIPTION
This change exposes the `actionType` parameter passed into the `action()` function as a property on the resulting wrapped action.