### PR TITLE
Implement satcheljs-promise

### DIFF
--- a/packages/satcheljs-promise/.npmignore
+++ b/packages/satcheljs-promise/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+test/

--- a/packages/satcheljs-promise/LICENSE
+++ b/packages/satcheljs-promise/LICENSE
@@ -1,0 +1,7 @@
+SatchelJS
+Copyright (c) Microsoft Corporation
+All rights reserved.
+MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/satcheljs-promise/README.md
+++ b/packages/satcheljs-promise/README.md
@@ -1,0 +1,5 @@
+[![npm version](https://badge.fury.io/js/satcheljs-promise.svg)](https://badge.fury.io/js/satcheljs-promise) [![Build Status](https://travis-ci.org/Microsoft/satcheljs-promise.svg?branch=master)](https://travis-ci.org/Microsoft/satcheljs-promise)
+
+# satcheljs-promise
+
+SatchelJS middleware to treat promise callbacks as actions.

--- a/packages/satcheljs-promise/jasmine.json
+++ b/packages/satcheljs-promise/jasmine.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "../../dist/satcheljs-promise/test",
+  "spec_files": [
+    "**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -6,7 +6,7 @@ let originalCatch: Function;
 
 export function setOriginalThenCatch(thenValue: Function, catchValue: Function) {
     originalThen = thenValue;
-    originalThen = catchValue;
+    originalCatch = catchValue;
 }
 
 export function wrappedThen(onFulfilled?: Function, onRejected?: Function) {

--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -28,7 +28,7 @@ function wrapInAction(callback: Function, callbackType: string) {
         return callback;
     }
 
-    let actionName = currentAction + "->" + callbackType
+    let actionName = currentAction + " => " + callbackType
     return function () {
         let returnValue;
         let args = arguments;

--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -1,0 +1,18 @@
+export type ThenType = typeof Promise.prototype.then;
+export type CatchType = typeof Promise.prototype.catch;
+
+let originalThen: ThenType;
+let originalCatch: CatchType;
+
+export function setOriginalThenCatch(thenValue: ThenType, catchValue: CatchType) {
+    originalThen = thenValue;
+    originalThen = catchValue;
+}
+
+export function wrappedThen() {
+    originalThen.apply(this, arguments);
+}
+
+export function wrappedCatch() {
+    originalCatch.apply(this, arguments);
+}

--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -1,13 +1,10 @@
 import { action } from 'satcheljs';
 import { getCurrentAction } from './promiseMiddleware';
 
-export type ThenType = typeof Promise.prototype.then;
-export type CatchType = typeof Promise.prototype.catch;
+let originalThen: Function;
+let originalCatch: Function;
 
-let originalThen: ThenType;
-let originalCatch: CatchType;
-
-export function setOriginalThenCatch(thenValue: ThenType, catchValue: CatchType) {
+export function setOriginalThenCatch(thenValue: Function, catchValue: Function) {
     originalThen = thenValue;
     originalThen = catchValue;
 }

--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -1,3 +1,6 @@
+import { action } from 'satcheljs';
+import { getCurrentAction } from './promiseMiddleware';
+
 export type ThenType = typeof Promise.prototype.then;
 export type CatchType = typeof Promise.prototype.catch;
 
@@ -9,10 +12,33 @@ export function setOriginalThenCatch(thenValue: ThenType, catchValue: CatchType)
     originalThen = catchValue;
 }
 
-export function wrappedThen() {
-    originalThen.apply(this, arguments);
+export function wrappedThen(onFulfilled?: Function, onRejected?: Function) {
+    return originalThen.call(
+        this,
+        wrapInAction(onFulfilled, "then"),
+        wrapInAction(onRejected, "then_rejected"));
 }
 
-export function wrappedCatch() {
-    originalCatch.apply(this, arguments);
+export function wrappedCatch(onRejected?: Function) {
+    return originalCatch.call(
+        this,
+        wrapInAction(onRejected, "catch"));
+}
+
+function wrapInAction(callback: Function, callbackType: string) {
+    let currentAction = getCurrentAction();
+    if (!currentAction || !callback) {
+        return callback;
+    }
+
+    let actionName = currentAction + "->" + callbackType
+    return function () {
+        let returnValue;
+        let args = arguments;
+        action(actionName)(() => {
+            returnValue = callback.apply(null, args);
+        })();
+
+        return returnValue;
+    }
 }

--- a/packages/satcheljs-promise/lib/index.ts
+++ b/packages/satcheljs-promise/lib/index.ts
@@ -1,0 +1,1 @@
+export { default as promiseMiddleware } from './promiseMiddleware';

--- a/packages/satcheljs-promise/lib/index.ts
+++ b/packages/satcheljs-promise/lib/index.ts
@@ -1,4 +1,1 @@
 export { promiseMiddleware } from './promiseMiddleware';
-
-import { install } from './install';
-install();

--- a/packages/satcheljs-promise/lib/index.ts
+++ b/packages/satcheljs-promise/lib/index.ts
@@ -1,1 +1,4 @@
 export { promiseMiddleware } from './promiseMiddleware';
+
+import { install } from './install';
+install();

--- a/packages/satcheljs-promise/lib/index.ts
+++ b/packages/satcheljs-promise/lib/index.ts
@@ -1,1 +1,1 @@
-export { default as promiseMiddleware } from './promiseMiddleware';
+export { promiseMiddleware } from './promiseMiddleware';

--- a/packages/satcheljs-promise/lib/install.ts
+++ b/packages/satcheljs-promise/lib/install.ts
@@ -1,0 +1,7 @@
+import { setOriginalThenCatch, wrappedThen, wrappedCatch } from './actionWrappers';
+
+export function install() {
+    setOriginalThenCatch(Promise.prototype.then, Promise.prototype.catch);
+    Promise.prototype.then = <any>wrappedThen;
+    Promise.prototype.catch = <any>wrappedCatch;
+}

--- a/packages/satcheljs-promise/lib/install.ts
+++ b/packages/satcheljs-promise/lib/install.ts
@@ -1,7 +1,12 @@
 import { setOriginalThenCatch, wrappedThen, wrappedCatch } from './actionWrappers';
 
-export function install() {
-    setOriginalThenCatch(Promise.prototype.then, Promise.prototype.catch);
-    Promise.prototype.then = <any>wrappedThen;
-    Promise.prototype.catch = <any>wrappedCatch;
+let isInstalled = false;
+
+export default function install() {
+    if (!isInstalled) {
+        setOriginalThenCatch(Promise.prototype.then, Promise.prototype.catch);
+        Promise.prototype.then = <any>wrappedThen;
+        Promise.prototype.catch = <any>wrappedCatch;
+        isInstalled = true;
+    }
 }

--- a/packages/satcheljs-promise/lib/promiseMiddleware.ts
+++ b/packages/satcheljs-promise/lib/promiseMiddleware.ts
@@ -1,5 +1,24 @@
 import { DispatchFunction, ActionFunction, ActionContext } from 'satcheljs';
 
-export default function promiseMiddleware(next: DispatchFunction, action: ActionFunction, actionType: string, args: IArguments, actionContext: ActionContext) {
-    return next(action, actionType, args, actionContext);
+let actionStack: string[] = [];
+
+export function getCurrentAction() {
+    return actionStack.length ? actionStack[actionStack.length - 1] : null;
+}
+
+export function promiseMiddleware(
+    next: DispatchFunction,
+    action: ActionFunction,
+    actionType: string,
+    args: IArguments,
+    actionContext: ActionContext)
+{
+    try
+    {
+        actionStack.push(actionType);
+        return next(action, actionType, args, actionContext);
+    }
+    finally {
+        actionStack.pop();
+    }
 }

--- a/packages/satcheljs-promise/lib/promiseMiddleware.ts
+++ b/packages/satcheljs-promise/lib/promiseMiddleware.ts
@@ -1,0 +1,5 @@
+import { DispatchFunction, ActionFunction, ActionContext } from 'satcheljs';
+
+export default function promiseMiddleware(next: DispatchFunction, action: ActionFunction, actionType: string, args: IArguments, actionContext: ActionContext) {
+    return next(action, actionType, args, actionContext);
+}

--- a/packages/satcheljs-promise/lib/promiseMiddleware.ts
+++ b/packages/satcheljs-promise/lib/promiseMiddleware.ts
@@ -1,4 +1,5 @@
 import { DispatchFunction, ActionFunction, ActionContext } from 'satcheljs';
+import install from './install';
 
 let actionStack: string[] = [];
 
@@ -13,6 +14,8 @@ export function promiseMiddleware(
     args: IArguments,
     actionContext: ActionContext)
 {
+    install();
+
     try
     {
         actionStack.push(actionType);

--- a/packages/satcheljs-promise/package.json
+++ b/packages/satcheljs-promise/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "satcheljs-promise",
+  "version": "2.11.0",
+  "description": "SatchelJS middleware to treat promise callbacks as actions",
+  "main": "./lib/index.js",
+  "scripts": {
+    "copy-project-files": "node ../../tools/copy-project-files.js",
+    "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
+    "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
+    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+  },
+  "author": "Scott Mikula <smikula@microsoft.com>",
+  "license": "MIT",
+  "dependencies": {
+    "satcheljs": "2.11.0"
+  },
+  "devDependencies": {
+    "jasmine": "~2.4.1",
+    "typescript": "~1.8.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/satcheljs"
+  },
+  "typings": "./lib/index.d.ts",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  }
+}

--- a/packages/satcheljs-promise/test/actionWrappersTests.ts
+++ b/packages/satcheljs-promise/test/actionWrappersTests.ts
@@ -1,0 +1,97 @@
+import 'jasmine';
+import * as satcheljs from 'satcheljs';
+import * as promiseMiddleware from '../lib/promiseMiddleware';
+import { setOriginalThenCatch, wrappedThen, wrappedCatch } from '../lib/actionWrappers';
+
+describe("actionWrappers", () => {
+
+    let originalThenSpy: jasmine.Spy;
+    let originalCatchSpy: jasmine.Spy;
+    let getCurrentActionSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        spyOn(satcheljs, "action").and.returnValue((callback: Function) => callback);
+        getCurrentActionSpy = spyOn(promiseMiddleware, "getCurrentAction");
+        originalThenSpy = jasmine.createSpy("originalThen");
+        originalCatchSpy = jasmine.createSpy("originalCatch");
+        setOriginalThenCatch(originalThenSpy, originalCatchSpy);
+    });
+
+    it("just pass through null callbacks", () => {
+        // Act
+        wrappedThen(null, null);
+        wrappedCatch(null);
+
+        // Assert
+        expect(originalThenSpy).toHaveBeenCalledWith(null, null);
+        expect(originalCatchSpy).toHaveBeenCalledWith(null);
+    });
+
+    it("when not in an action, just pass through the original callbacks", () => {
+        // Arrange
+        let onFulfilled = () => {};
+        let onRejected = () => {};
+
+        // Act
+        wrappedThen(onFulfilled, onRejected);
+        wrappedCatch(onRejected);
+
+        // Assert
+        expect(originalThenSpy).toHaveBeenCalledWith(onFulfilled, onRejected);
+        expect(originalCatchSpy).toHaveBeenCalledWith(onRejected);
+    });
+
+    it("when in an action, wrap the callbacks in actions", () => {
+        // Arrange
+        getCurrentActionSpy.and.returnValue("testAction");
+
+        let onFulfilled = jasmine.createSpy("onFulfilled");
+        let onRejectedInThen = jasmine.createSpy("onRejectedInThen");
+        wrappedThen(onFulfilled, onRejectedInThen);
+
+        let onRejectedInCatch = jasmine.createSpy("onRejectedInCatch");
+        wrappedCatch(onRejectedInCatch);
+
+        // Act / Assert
+        fulfillPromise();
+        expect(satcheljs.action).toHaveBeenCalledWith("testAction => then");
+        expect(onFulfilled).toHaveBeenCalled();
+
+        rejectPromiseInThen();
+        expect(satcheljs.action).toHaveBeenCalledWith("testAction => then_rejected");
+        expect(onRejectedInThen).toHaveBeenCalled();
+
+        rejectPromiseInCatch();
+        expect(satcheljs.action).toHaveBeenCalledWith("testAction => catch");
+        expect(onRejectedInCatch).toHaveBeenCalled();
+    });
+
+    it("handle callback parameters and return value", () => {
+        // Arrange
+        getCurrentActionSpy.and.returnValue("testAction");
+        let onFulfilled = jasmine.createSpy("onFulfilled").and.returnValue("returnValue");
+
+        // Act
+        wrappedThen(onFulfilled, null);
+
+        // Simulate the promise being fulfilled
+        let returnValue = fulfillPromise("arg");
+
+        // Assert
+        expect(returnValue).toBe("returnValue");
+        expect(onFulfilled).toHaveBeenCalledWith("arg");
+    });
+
+    function fulfillPromise(arg?: any) {
+        return originalThenSpy.calls.argsFor(0)[0](arg);
+    }
+
+    function rejectPromiseInThen(arg?: any) {
+        return originalThenSpy.calls.argsFor(0)[1](arg);
+    }
+
+    function rejectPromiseInCatch(arg?: any) {
+        return originalCatchSpy.calls.argsFor(0)[0](arg);
+    }
+
+});

--- a/packages/satcheljs-promise/test/endToEndTests.ts
+++ b/packages/satcheljs-promise/test/endToEndTests.ts
@@ -1,0 +1,56 @@
+import 'jasmine';
+import { action, applyMiddleware, createStore } from 'satcheljs';
+import { getCurrentAction, promiseMiddleware } from '../lib/promiseMiddleware';
+import { install } from '../lib/install';
+
+describe("promiseMiddleware", () => {
+
+    beforeAll(() => {
+        install();
+    });
+
+    it("wraps callbacks in promises when applied", (done) => {
+        // Arrange
+        applyMiddleware(promiseMiddleware);
+        let store = createStore("testStore", { testValue: null });
+        let newValue = {};
+
+        // Act
+        testAction(store, newValue).then(() => {
+            // Assert that the value was set
+            expect(store.testValue).toBe(newValue);
+            done();
+        }).catch((error) => {
+            // Assert that the action does not fail
+            fail("Action failed with error: " + error);
+            done();
+        });
+    });
+
+    it("does not wrap callbacks in promises when not applied", (done) => {
+        // Arrange
+        applyMiddleware();
+        let store = createStore("testStore", { testValue: null });
+        let newValue = {};
+
+        // Act
+        testAction(store, newValue).then(() => {
+            // Assert that the action fails
+            fail("The action should fail.");
+            done();
+        }).catch((error) => {
+            // Assert that the value was not set
+            expect(store.testValue).not.toBe(newValue);
+            done();
+        });
+    });
+
+});
+
+
+let testAction = action("testAction")(
+    function testAction(store: any, newValue: any) {
+        return Promise.resolve(newValue).then((value) => {
+            store.testValue = value;
+        });
+    });

--- a/packages/satcheljs-promise/test/endToEndTests.ts
+++ b/packages/satcheljs-promise/test/endToEndTests.ts
@@ -21,7 +21,7 @@ describe("promiseMiddleware", () => {
             expect(store.testValue).toBe(newValue);
 
             // The action name should indicate that it was a promise's "then" callback
-            expect(store.currentAction).toBe("testAction->then");
+            expect(store.currentAction).toBe("testAction => then");
 
             // At this point there should be no current action
             expect(getCurrentAction()).toBe(null);

--- a/packages/satcheljs-promise/test/endToEndTests.ts
+++ b/packages/satcheljs-promise/test/endToEndTests.ts
@@ -12,13 +12,19 @@ describe("promiseMiddleware", () => {
     it("wraps callbacks in promises when applied", (done) => {
         // Arrange
         applyMiddleware(promiseMiddleware);
-        let store = createStore("testStore", { testValue: null });
+        let store = createStore("testStore", { testValue: null, currentAction: null });
         let newValue = {};
 
         // Act
         testAction(store, newValue).then(() => {
-            // Assert that the value was set
+            // The new value should have been set
             expect(store.testValue).toBe(newValue);
+
+            // The action name should indicate that it was a promise's "then" callback
+            expect(store.currentAction).toBe("testAction->then");
+
+            // At this point there should be no current action
+            expect(getCurrentAction()).toBe(null);
             done();
         }).catch((error) => {
             // Assert that the action does not fail
@@ -52,5 +58,6 @@ let testAction = action("testAction")(
     function testAction(store: any, newValue: any) {
         return Promise.resolve(newValue).then((value) => {
             store.testValue = value;
+            store.currentAction = getCurrentAction();
         });
     });

--- a/packages/satcheljs-promise/test/endToEndTests.ts
+++ b/packages/satcheljs-promise/test/endToEndTests.ts
@@ -1,13 +1,8 @@
 import 'jasmine';
 import { action, applyMiddleware, createStore } from 'satcheljs';
 import { getCurrentAction, promiseMiddleware } from '../lib/promiseMiddleware';
-import { install } from '../lib/install';
 
 describe("promiseMiddleware", () => {
-
-    beforeAll(() => {
-        install();
-    });
 
     it("wraps callbacks in promises when applied", (done) => {
         // Arrange

--- a/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
+++ b/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import promiseMiddleware from '../lib/promiseMiddleware';
+import { getCurrentAction, promiseMiddleware } from '../lib/promiseMiddleware';
 
 describe("promiseMiddleware", () => {
 
@@ -21,6 +21,39 @@ describe("promiseMiddleware", () => {
 
         // Assert
         expect(next).toHaveBeenCalledWith(originalAction, originalActionType, originalArguments, originalActionContext);
+    });
+
+    it("keeps track of the current action", () => {
+        // Arrange
+        let actionType = "testAction";
+        let currentAction;
+        let next = () => { currentAction = getCurrentAction(); };
+
+        // Act
+        promiseMiddleware(next, null, actionType, null, null);
+
+        // Assert
+        expect(currentAction).toBe(actionType);
+    });
+
+    it("keeps track of recursive actions", () => {
+        // Arrange
+        let outerAction = "outerAction";
+        let innerAction = "innerAction";
+        let currentActionValues: string[] = [];
+
+        // Act
+        let outerNext = () => {
+            currentActionValues.push(getCurrentAction());
+            let innerNext = () => { currentActionValues.push(getCurrentAction()); };
+            promiseMiddleware(innerNext, null, innerAction, null, null);
+            currentActionValues.push(getCurrentAction());
+        };
+
+        promiseMiddleware(outerNext, null, outerAction, null, null);
+
+        // Assert
+        expect(currentActionValues).toEqual([ outerAction, innerAction, outerAction ]);
     });
 
 });

--- a/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
+++ b/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
@@ -1,7 +1,20 @@
 import 'jasmine';
 import { getCurrentAction, promiseMiddleware } from '../lib/promiseMiddleware';
+import * as install from '../lib/install';
 
 describe("promiseMiddleware", () => {
+
+    beforeEach(() => {
+        spyOn(install, "default");
+    });
+
+    it("calls install to monkeypatch Promise", () => {
+        // Act
+        promiseMiddleware(() => {}, null, null, null, null);
+
+        // Assert
+        expect(install.default).toHaveBeenCalled();
+    });
 
     it("calls next with arguments", () => {
         // Arrange

--- a/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
+++ b/packages/satcheljs-promise/test/promiseMiddlewareTests.ts
@@ -1,0 +1,26 @@
+import 'jasmine';
+import promiseMiddleware from '../lib/promiseMiddleware';
+
+describe("promiseMiddleware", () => {
+
+    it("calls next with arguments", () => {
+        // Arrange
+        let originalAction = () => {};
+        let originalActionType = "testAction";
+        let originalArguments = <IArguments>{};
+        let originalActionContext = {a:1}
+        let next = jasmine.createSpy("next");
+
+        // Act
+        promiseMiddleware(
+            next,
+            originalAction,
+            originalActionType,
+            originalArguments,
+            originalActionContext);
+
+        // Assert
+        expect(next).toHaveBeenCalledWith(originalAction, originalActionType, originalArguments, originalActionContext);
+    });
+
+});

--- a/packages/satcheljs-promise/tsconfig.json
+++ b/packages/satcheljs-promise/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "jsx": "react",
+    "outDir": "../../dist/satcheljs-promise",
+    "sourceMap": false,
+    "declaration": true,
+    "removeComments": false,
+    "noImplicitAny": true,
+    "paths": {
+      "*": [
+        "*",
+        "dist/*"
+      ]
+    },
+    "baseUrl": "../../",
+    "rootDir": "."
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
+  "include": [
+    "lib/**/*.ts",
+    "lib/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx",
+    "typings/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
This introduces satcheljs-promise, which is a middleware that overrides the default Promise's `then` and `catch` methods to create actions out of the fulfilled/rejected callbacks.  This makes it simple to write actions that do asynchronous work, either via promises or async/await, without having to manually wrap everything that happens asynchronously in separate actions.