### PR TITLE
Simplify satcheljs-trace middleware

### DIFF
--- a/packages/satcheljs-trace/lib/trace.ts
+++ b/packages/satcheljs-trace/lib/trace.ts
@@ -15,6 +15,6 @@ export default function trace(next: DispatchFunction, action: ActionFunction, ac
 }
 
 function log(message: string) {
-    let indentation = (new Array(depth)).join('  ');
+    let indentation = (new Array(depth + 1)).join('  ');
     console.log(indentation + message);
 }

--- a/packages/satcheljs-trace/lib/trace.ts
+++ b/packages/satcheljs-trace/lib/trace.ts
@@ -1,26 +1,20 @@
 import { DispatchFunction, ActionFunction, ActionContext } from 'satcheljs';
 
+let depth = 0;
+
 export default function trace(next: DispatchFunction, action: ActionFunction, actionType: string, args: IArguments, actionContext: ActionContext) {
-    groupStart("Executing action: " + (actionType ? actionType : "(anonymous action)"));
+    log("Executing action: " + (actionType ? actionType : "(anonymous action)"));
 
     try {
+        depth++;
         return next(action, actionType, args, actionContext);
     }
     finally {
-        groupEnd();
+        depth--;
     }
 }
 
-function groupStart(message: string) {
-    if (typeof console.group == "function") {
-        console.group(message);
-    } else {
-        console.log(message);
-    }
-}
-
-function groupEnd() {
-    if (typeof console.groupEnd == "function") {
-        console.groupEnd();
-    }
+function log(message: string) {
+    let indentation = (new Array(depth)).join('  ');
+    console.log(indentation + message);
 }


### PR DESCRIPTION
This gets rid of the console grouping logic so that we're just using normal console.log calls to write to the console.