### PR TITLE
Implement raiseAction and deprecate raise

### DIFF
--- a/packages/satcheljs-stitch/lib/index.ts
+++ b/packages/satcheljs-stitch/lib/index.ts
@@ -1,1 +1,1 @@
-export { stitch, subscribe, raise } from './stitch';
+export { stitch, subscribe, raise, raiseAction } from './stitch';

--- a/packages/satcheljs-stitch/lib/stitch.ts
+++ b/packages/satcheljs-stitch/lib/stitch.ts
@@ -28,6 +28,8 @@ export function subscribe<T extends ActionHandler>(actionType: string, callback:
 }
 
 export function raise<T extends ActionHandler>(actionType: string, callback?: (actionToExecute: T) => void) {
+    console.error("[satcheljs-stitch] The 'raise' API is deprecated.  Use 'raiseAction' instead.");
+
     // Create a no-op action to execute
     let actionToExecute = action(actionType)(() => {});
 
@@ -38,4 +40,9 @@ export function raise<T extends ActionHandler>(actionType: string, callback?: (a
         // No callback was provided, so just execute it with no arguments
         actionToExecute();
     }
+}
+
+export function raiseAction<T extends ActionHandler>(actionType: string): T {
+    // Create a no-op action to execute
+    return <T>action(actionType)(() => {});
 }

--- a/packages/satcheljs-stitch/test/raiseActionTests.ts
+++ b/packages/satcheljs-stitch/test/raiseActionTests.ts
@@ -1,0 +1,24 @@
+import 'jasmine';
+import * as satcheljsImports from 'satcheljs';
+import { raiseAction } from '../lib/stitch';
+
+interface TestActionType {
+    (arg1: string, arg2: string): void;
+}
+
+describe("raiseAction", () => {
+
+    it("returns a dummy action of the given type", () => {
+        // Arrange
+        let createdAction = jasmine.createSpy("createdAction");
+        spyOn(satcheljsImports, "action").and.returnValue((rawAction: Function) => createdAction);
+
+        // Act
+        raiseAction<TestActionType>("testAction")("arg1", "arg2");
+
+        // Assert
+        expect(satcheljsImports.action).toHaveBeenCalledWith("testAction");
+        expect(createdAction).toHaveBeenCalledWith("arg1", "arg2");
+    });
+
+});

--- a/packages/satcheljs-stitch/test/raiseTests.ts
+++ b/packages/satcheljs-stitch/test/raiseTests.ts
@@ -4,6 +4,10 @@ import { stitch, subscribe, raise } from '../lib/stitch';
 
 describe("raise", () => {
 
+    beforeEach(() => {
+        spyOn(console, "error");
+    });
+
     it("creates an action of the given type", () => {
         spyOn(satcheljsImports, "action").and.returnValue((rawAction: Function) => rawAction);
         raise("testAction");


### PR DESCRIPTION
This addresses #45.  Because it is not possible to make this change in a backward compatible way, I created a new API called `raiseAction` and deprecated `raise`.