### PR TITLE
Change the way we expose action type

### DIFF
--- a/packages/satcheljs/lib/RawAction.ts
+++ b/packages/satcheljs/lib/RawAction.ts
@@ -1,0 +1,5 @@
+interface RawAction {
+    (... args: any[]): Promise<any> | void;
+}
+
+export default RawAction;

--- a/packages/satcheljs/lib/action.ts
+++ b/packages/satcheljs/lib/action.ts
@@ -3,12 +3,8 @@ import dispatch from './dispatch';
 import RawAction from './RawAction';
 import { setActionType, setOriginalTarget } from './functionInternals';
 
-export interface Action {
-    actionType?: string;
-}
-
 export interface ActionFactory {
-    <T extends RawAction>(target: T): T & Action;
+    <T extends RawAction>(target: T): T;
     <T extends RawAction>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): void;
 }
 
@@ -22,8 +18,8 @@ export default function action(actionType: string, actionContext?: ActionContext
     } as ActionFactory;
 }
 
-function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string, actionContext: ActionContext): T & Action {
-    let decoratedTarget: T & Action = <T>function() {
+function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string, actionContext: ActionContext): T {
+    let decoratedTarget: T = <T>function() {
         let returnValue: any;
         let passedArguments = arguments;
 
@@ -35,7 +31,6 @@ function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string
 
         return returnValue;
     };
-    decoratedTarget.actionType = actionType;
 
     setOriginalTarget(decoratedTarget, target);
     setActionType(decoratedTarget, actionType);

--- a/packages/satcheljs/lib/action.ts
+++ b/packages/satcheljs/lib/action.ts
@@ -1,10 +1,7 @@
 import ActionContext from './ActionContext';
 import dispatch from './dispatch';
-import {setOriginalTarget} from './functionInternals';
-
-export interface RawAction {
-    (... args: any[]): Promise<any> | void;
-}
+import RawAction from './RawAction';
+import { setActionType, setOriginalTarget } from './functionInternals';
 
 export interface Action {
     actionType?: string;
@@ -41,6 +38,7 @@ function wrapFunctionInAction<T extends RawAction>(target: T, actionType: string
     decoratedTarget.actionType = actionType;
 
     setOriginalTarget(decoratedTarget, target);
+    setActionType(decoratedTarget, actionType);
 
     return decoratedTarget;
 }

--- a/packages/satcheljs/lib/functionInternals.ts
+++ b/packages/satcheljs/lib/functionInternals.ts
@@ -1,3 +1,5 @@
+import RawAction from './RawAction';
+
 export function setOriginalTarget(decoratedTarget: any, originalTarget: any) {
     decoratedTarget.__SATCHELJS_ORIGINAL_TARGET = originalTarget;
 }
@@ -6,6 +8,14 @@ export function getOriginalTarget(decoratedTarget: any) {
     if (typeof decoratedTarget.__SATCHELJS_ORIGINAL_TARGET !== typeof undefined) {
         return decoratedTarget.__SATCHELJS_ORIGINAL_TARGET;
     }
-    
+
     return undefined;
+}
+
+export function setActionType(decoratedTarget: any, actionType: string) {
+    decoratedTarget.__SATCHELJS_ACTION_TYPE = actionType;
+}
+
+export function getActionType(decoratedTarget: RawAction) {
+    return (<any>decoratedTarget).__SATCHELJS_ACTION_TYPE;
 }

--- a/packages/satcheljs/lib/index.ts
+++ b/packages/satcheljs/lib/index.ts
@@ -9,5 +9,6 @@ export { default as createStore } from './createStore';
 export { default as action } from './action';
 export { default as select, SelectorFunction } from './select';
 export { default as createUndo, UndoResult, CreateUndoReturnValue} from './createUndo';
+export { getActionType } from './functionInternals';
 export { initializeTestMode, resetTestMode } from './testMode';
 export { useStrict } from './useStrict';

--- a/packages/satcheljs/lib/select.ts
+++ b/packages/satcheljs/lib/select.ts
@@ -1,5 +1,5 @@
 import {Reaction, Atom, IObservableValue, isObservableArray} from 'mobx';
-import {getOriginalTarget} from './functionInternals';
+import {getOriginalTarget, getActionType, setActionType} from './functionInternals';
 import {getGlobalContext} from './globalContext';
 
 export type SelectorFunction<T> = {
@@ -94,6 +94,7 @@ export default function select<T>(selector: SelectorFunction<T>) {
             return target.apply(context, args);
         }
 
+        setActionType(returnValue, getActionType(<any>target));
         return <Target>returnValue;
     }
 }

--- a/packages/satcheljs/test/actionTests.ts
+++ b/packages/satcheljs/test/actionTests.ts
@@ -2,6 +2,7 @@ import 'jasmine';
 import action from '../lib/action';
 import * as dispatchImports from '../lib/dispatch';
 import { getGlobalContext } from '../lib/globalContext';
+import { getActionType } from '../lib/functionInternals';
 
 describe("action", () => {
     it("wraps the function call in a dispatch", () => {
@@ -30,7 +31,7 @@ describe("action", () => {
 
         let wrappedAction = action(actionType)(testFunction);
 
-        expect(wrappedAction.actionType).toBe(actionType)
+        expect(getActionType(wrappedAction)).toBe(actionType);
     });
 
     it("passes on the original arguments", () => {
@@ -88,6 +89,6 @@ describe("action", () => {
 
         let testInstance = new TestClass();
 
-        expect((testInstance.testMethod as any).actionType).toBe(actionType);
+        expect(getActionType(testInstance.testMethod)).toBe(actionType);
     });
 });

--- a/packages/satcheljs/test/selectTest.ts
+++ b/packages/satcheljs/test/selectTest.ts
@@ -4,6 +4,7 @@ import action from '../lib/action';
 import select from '../lib/select';
 import createStore from '../lib/createStore';
 import {initializeTestMode, resetTestMode} from '../lib/testMode';
+import { getActionType } from '../lib/functionInternals';
 
 describe("select", () => {
     it("creates a state scoped to subset of state tree", () => {
@@ -289,5 +290,17 @@ describe("select", () => {
 
         expect(fooSelector).toHaveBeenCalled();
         expect(actionSpy).toHaveBeenCalled();
+    });
+
+    it("when wrapping an action, preserves the action type", () => {
+        // Arrange
+        let actionName = "testAction";
+        let testAction = action(actionName)(() => {});
+
+        // Act
+        let wrappedAction = select({})(testAction);
+
+        // Assert
+        expect(getActionType(wrappedAction)).toBe(actionName);
     });
 });


### PR DESCRIPTION
The way we expose an actionType property off actions is problematic because in order to generate definition files you need to export the `Action` type anywhere you export an action.  This PR is a stab at a different way to do it: stamp a private property on the action (i.e. don't expose it via an interface) and have Satchel export a getter function that can read and return that private property.  But I'm open to other ideas.