### PR TITLE
Fix package-level npm test scripts

### DIFF
--- a/packages/satcheljs-promise/package.json
+++ b/packages/satcheljs-promise/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",

--- a/packages/satcheljs-react-devtools/package.json
+++ b/packages/satcheljs-react-devtools/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",

--- a/packages/satcheljs-react/package.json
+++ b/packages/satcheljs-react/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Ken Chau <kchau@microsoft.com>",
   "license": "MIT",

--- a/packages/satcheljs-snapshots/package.json
+++ b/packages/satcheljs-snapshots/package.json
@@ -8,7 +8,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "repository": {
     "type": "git",

--- a/packages/satcheljs-stitch/package.json
+++ b/packages/satcheljs-stitch/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",

--- a/packages/satcheljs-trace/package.json
+++ b/packages/satcheljs-trace/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",

--- a/packages/satcheljs/package.json
+++ b/packages/satcheljs/package.json
@@ -7,7 +7,7 @@
     "copy-project-files": "node ../../tools/copy-project-files.js",
     "build": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js",
     "start": "npm run copy-project-files && node ../../node_modules/typescript/lib/tsc.js -w",
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json --verbose"
+    "test": "node ../../node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=jasmine.json --verbose"
   },
   "author": "Scott Mikula <smikula@microsoft.com>",
   "license": "MIT",


### PR DESCRIPTION
Running `npm test` didn't work underneath individual packages.  This fixes that.