### PR TITLE
Change satcheljs-promise to override Promise in a more reliable way

### DIFF
--- a/packages/satcheljs-promise/lib/actionWrappers.ts
+++ b/packages/satcheljs-promise/lib/actionWrappers.ts
@@ -1,25 +1,21 @@
 import { action } from 'satcheljs';
 import { getCurrentAction } from './promiseMiddleware';
 
-let originalThen: Function;
-let originalCatch: Function;
-
-export function setOriginalThenCatch(thenValue: Function, catchValue: Function) {
-    originalThen = thenValue;
-    originalCatch = catchValue;
+export function wrapThen(originalThen: any) {
+    return function wrappedThen(onFulfilled?: Function, onRejected?: Function) {
+        return originalThen.call(
+            this,
+            wrapInAction(onFulfilled, "then"),
+            wrapInAction(onRejected, "then_rejected"));
+        };
 }
 
-export function wrappedThen(onFulfilled?: Function, onRejected?: Function) {
-    return originalThen.call(
-        this,
-        wrapInAction(onFulfilled, "then"),
-        wrapInAction(onRejected, "then_rejected"));
-}
-
-export function wrappedCatch(onRejected?: Function) {
-    return originalCatch.call(
-        this,
-        wrapInAction(onRejected, "catch"));
+export function wrapCatch(originalCatch: any) {
+    return function wrappedCatch(onRejected?: Function) {
+        return originalCatch.call(
+            this,
+            wrapInAction(onRejected, "catch"));
+    };
 }
 
 function wrapInAction(callback: Function, callbackType: string) {

--- a/packages/satcheljs-promise/lib/install.ts
+++ b/packages/satcheljs-promise/lib/install.ts
@@ -1,12 +1,14 @@
-import { setOriginalThenCatch, wrappedThen, wrappedCatch } from './actionWrappers';
-
-let isInstalled = false;
+import { wrapThen, wrapCatch } from './actionWrappers';
 
 export default function install() {
-    if (!isInstalled) {
-        setOriginalThenCatch(Promise.prototype.then, Promise.prototype.catch);
-        Promise.prototype.then = <any>wrappedThen;
-        Promise.prototype.catch = <any>wrappedCatch;
-        isInstalled = true;
-    }
+    let originalThen = Promise.prototype.then;
+    let originalCatch = Promise.prototype.catch;
+
+    Promise.prototype.then = wrapThen(originalThen);
+    Promise.prototype.catch = wrapCatch(originalCatch);
+
+    return function uninstall() {
+        Promise.prototype.then = originalThen;
+        Promise.prototype.catch = originalCatch;
+    };
 }

--- a/packages/satcheljs-promise/lib/promiseMiddleware.ts
+++ b/packages/satcheljs-promise/lib/promiseMiddleware.ts
@@ -2,6 +2,8 @@ import { DispatchFunction, ActionFunction, ActionContext } from 'satcheljs';
 import install from './install';
 
 let actionStack: string[] = [];
+let isInstalled = false;
+let uninstall: () => void;
 
 export function getCurrentAction() {
     return actionStack.length ? actionStack[actionStack.length - 1] : null;
@@ -14,7 +16,11 @@ export function promiseMiddleware(
     args: IArguments,
     actionContext: ActionContext)
 {
-    install();
+    // If we're not already installed, install now
+    if (!isInstalled) {
+        uninstall = install();
+        isInstalled = true;
+    }
 
     try
     {
@@ -23,5 +29,11 @@ export function promiseMiddleware(
     }
     finally {
         actionStack.pop();
+
+        // If we're no longer in an action, uninstall
+        if (!actionStack.length) {
+            uninstall();
+            isInstalled = false;
+        }
     }
 }

--- a/packages/satcheljs-promise/test/actionWrappersTests.ts
+++ b/packages/satcheljs-promise/test/actionWrappersTests.ts
@@ -1,7 +1,7 @@
 import 'jasmine';
 import * as satcheljs from 'satcheljs';
 import * as promiseMiddleware from '../lib/promiseMiddleware';
-import { setOriginalThenCatch, wrappedThen, wrappedCatch } from '../lib/actionWrappers';
+import { wrapThen, wrapCatch } from '../lib/actionWrappers';
 
 describe("actionWrappers", () => {
 
@@ -14,43 +14,28 @@ describe("actionWrappers", () => {
         getCurrentActionSpy = spyOn(promiseMiddleware, "getCurrentAction");
         originalThenSpy = jasmine.createSpy("originalThen");
         originalCatchSpy = jasmine.createSpy("originalCatch");
-        setOriginalThenCatch(originalThenSpy, originalCatchSpy);
     });
 
     it("just pass through null callbacks", () => {
         // Act
-        wrappedThen(null, null);
-        wrappedCatch(null);
+        wrapThen(originalThenSpy)(null, null);
+        wrapCatch(originalCatchSpy)(null);
 
         // Assert
         expect(originalThenSpy).toHaveBeenCalledWith(null, null);
         expect(originalCatchSpy).toHaveBeenCalledWith(null);
     });
 
-    it("when not in an action, just pass through the original callbacks", () => {
-        // Arrange
-        let onFulfilled = () => {};
-        let onRejected = () => {};
-
-        // Act
-        wrappedThen(onFulfilled, onRejected);
-        wrappedCatch(onRejected);
-
-        // Assert
-        expect(originalThenSpy).toHaveBeenCalledWith(onFulfilled, onRejected);
-        expect(originalCatchSpy).toHaveBeenCalledWith(onRejected);
-    });
-
-    it("when in an action, wrap the callbacks in actions", () => {
+    it("wrap the callbacks in actions", () => {
         // Arrange
         getCurrentActionSpy.and.returnValue("testAction");
 
         let onFulfilled = jasmine.createSpy("onFulfilled");
         let onRejectedInThen = jasmine.createSpy("onRejectedInThen");
-        wrappedThen(onFulfilled, onRejectedInThen);
+        wrapThen(originalThenSpy)(onFulfilled, onRejectedInThen);
 
         let onRejectedInCatch = jasmine.createSpy("onRejectedInCatch");
-        wrappedCatch(onRejectedInCatch);
+        wrapCatch(originalCatchSpy)(onRejectedInCatch);
 
         // Act / Assert
         fulfillPromise();
@@ -72,7 +57,7 @@ describe("actionWrappers", () => {
         let onFulfilled = jasmine.createSpy("onFulfilled").and.returnValue("returnValue");
 
         // Act
-        wrappedThen(onFulfilled, null);
+        wrapThen(originalThenSpy)(onFulfilled, null);
 
         // Simulate the promise being fulfilled
         let returnValue = fulfillPromise("arg");

--- a/packages/satcheljs-promise/test/installTests.ts
+++ b/packages/satcheljs-promise/test/installTests.ts
@@ -1,0 +1,44 @@
+import 'jasmine';
+import * as actionWrappers from '../lib/actionWrappers';
+import install from '../lib/install';
+
+describe("install", () => {
+
+    let originalThen = Promise.prototype.then;
+    let originalCatch = Promise.prototype.catch;
+
+    let wrappedThen = () => {};
+    let wrappedCatch = () => {};
+
+    beforeEach(() => {
+        spyOn(actionWrappers, 'wrapThen').and.returnValue(wrappedThen);
+        spyOn(actionWrappers, 'wrapCatch').and.returnValue(wrappedCatch);
+    });
+
+    afterEach(() => {
+        Promise.prototype.then = originalThen;
+        Promise.prototype.catch = originalCatch;
+    });
+
+    it("wraps Promise.then and Promise.catch", () => {
+        // Act
+        install();
+
+        // Assert
+        expect(Promise.prototype.then).toBe(wrappedThen);
+        expect(Promise.prototype.catch).toBe(wrappedCatch);
+    });
+
+    it("returns an uninstall function to restore the original then and catch", () => {
+        // Arrange
+        let uninstall = install();
+
+        // Act
+        uninstall();
+
+        // Assert
+        expect(Promise.prototype.then).toBe(originalThen);
+        expect(Promise.prototype.catch).toBe(originalCatch);
+    });
+
+});


### PR DESCRIPTION
The satcheljs-promise middleware has problems in cases where a polyfill overrides `Promise` after the middleware has been installed.  This changes it so that `Promise.then` and `Promise.catch` are monkeypatched (and cleaned up) on demand rather than just doing it once at the start.