### PR TITLE
Update publish-all task to publish prerelease builds with a 'next' tag

### DIFF
--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -21,14 +21,20 @@ packages.forEach((package) => {
         fs.writeFileSync(pkgNpmrc, fs.readFileSync(pkgNpmrc).toString() + "\n//registry.npmjs.org/:_authToken=" + process.env['NPM_AUTH_TOKEN'] + "\n");
     }
 
-    console.log("Branch: ", process.env['TRAVIS_BRANCH']);
+    // If we're publishing from a branch other than master, tag the release with the branch name
+    let publishCommand = 'npm publish';
+    let branch = process.env['TRAVIS_BRANCH'];
+    if (branch != 'master') {
+        publishCommand += ` --tag ${branch}`;
+    }
 
-    // try {
-    //     console.log(`Publishing to registry`);
-    //     var results = exec(`npm publish`, {cwd: cwd });
-    // } catch (err) {
-    //     console.error(`Build error ${err.message}`);
-    // }
+    try {
+        console.log(`Publishing to registry`);
+        console.log(publishCommand);
+        //var results = exec(publishCommand, {cwd: cwd });
+    } catch (err) {
+        console.error(`Build error ${err.message}`);
+    }
 
     console.log(results.toString());
 });

--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -32,11 +32,10 @@ packages.forEach((package) => {
     try {
         console.log(`Publishing to registry`);
         console.log(publishCommand);
-        //var results = exec(publishCommand, {cwd: cwd });
+        var results = exec(publishCommand, {cwd: cwd });
     } catch (err) {
         console.error(`Build error ${err.message}`);
     }
 
-    //console.log(results.toString());
+    console.log(results.toString());
 });
-

--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -23,7 +23,8 @@ packages.forEach((package) => {
 
     // If we're publishing from a branch other than master, tag the release with the branch name
     let publishCommand = 'npm publish';
-    let branch = process.env['TRAVIS_BRANCH'];
+    //let branch = process.env['TRAVIS_BRANCH'];
+    let branch = exec('git symbolic-ref --short HEAD', {cwd: cwd, stdio: 'inherit'});
     if (branch != 'master') {
         publishCommand += ` --tag ${branch}`;
     }
@@ -36,6 +37,6 @@ packages.forEach((package) => {
         console.error(`Build error ${err.message}`);
     }
 
-    console.log(results.toString());
+    //console.log(results.toString());
 });
 

--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -21,12 +21,14 @@ packages.forEach((package) => {
         fs.writeFileSync(pkgNpmrc, fs.readFileSync(pkgNpmrc).toString() + "\n//registry.npmjs.org/:_authToken=" + process.env['NPM_AUTH_TOKEN'] + "\n");
     }
 
-    try {
-        console.log(`Publishing to registry`);
-        var results = exec(`npm publish`, {cwd: cwd });
-    } catch (err) {
-        console.error(`Build error ${err.message}`);
-    }
+    console.log("Branch: ", process.env['TRAVIS_BRANCH']);
+
+    // try {
+    //     console.log(`Publishing to registry`);
+    //     var results = exec(`npm publish`, {cwd: cwd });
+    // } catch (err) {
+    //     console.error(`Build error ${err.message}`);
+    // }
 
     console.log(results.toString());
 });

--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -32,7 +32,7 @@ packages.forEach((package) => {
     try {
         console.log(`Publishing to registry`);
         console.log(publishCommand);
-        var results = exec(publishCommand, {cwd: cwd });
+        var results = exec(publishCommand, { cwd: cwd });
     } catch (err) {
         console.error(`Build error ${err.message}`);
     }

--- a/tools/publish-all.js
+++ b/tools/publish-all.js
@@ -21,12 +21,12 @@ packages.forEach((package) => {
         fs.writeFileSync(pkgNpmrc, fs.readFileSync(pkgNpmrc).toString() + "\n//registry.npmjs.org/:_authToken=" + process.env['NPM_AUTH_TOKEN'] + "\n");
     }
 
-    // If we're publishing from a branch other than master, tag the release with the branch name
+    // If this is a prerelease, tag the release as 'next'.  Prereleases have
+    // hyphens in the version tag, e.g. 'v3.0.0-beta1'.
     let publishCommand = 'npm publish';
-    //let branch = process.env['TRAVIS_BRANCH'];
-    let branch = exec('git symbolic-ref --short HEAD', {cwd: cwd, stdio: 'inherit'});
-    if (branch != 'master') {
-        publishCommand += ` --tag ${branch}`;
+    let tag = process.env['TRAVIS_TAG'];
+    if (tag.indexOf('-') > 0) {
+        publishCommand += ` --tag next`;
     }
 
     try {


### PR DESCRIPTION
This is a bit of a hack, but there's no great way to tell that a release is a prerelease within the Travis CI build environment.  Ideally we would treat builds in branches other than master as prereleases, but the branch name is not available when the build is based on a git tag.  My solution is to look at the tag itself.  By convention, tags for prereleases will have a hyphen in them, e.g. `v3.0.0-beta1`.