### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
     "test": "npm run build && npm run link-all && node tools/test-all.js"
   },
   "devDependencies": {
-    "@types/enzyme": "^2.5.38",
-    "@types/jasmine": "^2.5.47",
-    "@types/jsdom": "^2.0.29",
-    "@types/node": "^6.0.48",
+    "@types/enzyme": "~2.8.1",
+    "@types/jasmine": "~2.5.53",
+    "@types/jsdom": "~2.0.32",
+    "@types/node": "~6.0.78",
     "@types/react": "~15.0.27",
-    "@types/react-addons-perf": "~0.14.17",
-    "@types/react-addons-test-utils": "^0.14.15",
-    "@types/react-dom": "~0.14.18",
+    "@types/react-addons-perf": "~0.14.18",
+    "@types/react-addons-test-utils": "~0.14.19",
+    "@types/react-dom": "~15.5.1",
     "enzyme": "~2.6.0",
     "glob": "^7.0.6",
     "jasmine": "~2.5.3",
     "jsdom": "~9.8.3",
     "mkdirp": "^0.5.1",
-    "react-addons-test-utils": "^15.4.0",
+    "react-addons-test-utils": "~15.6.0",
     "rimraf": "^2.5.4",
     "toposort": "~1.0.0",
     "tslint": "^4.0.2",
@@ -36,8 +36,8 @@
     "mobx": "~2.6.5",
     "mobx-react": "~4.0.3",
     "mobx-react-devtools": "~4.2.10",
-    "react": "^15.4.0",
-    "react-addons-perf": "^15.4.0",
-    "react-dom": "^15.4.0"
+    "react": "^15.6.1",
+    "react-addons-perf": "^15.4.2",
+    "react-dom": "^15.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "tslint": "^4.0.2",
     "tslint-eslint-rules": "^3.2.0",
     "tslint-microsoft-contrib": "^4.0.0",
-    "typescript": "~2.1.4"
+    "typescript": "~2.3.4"
   },
   "dependencies": {
     "mobx": "~2.6.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/jasmine": "^2.5.47",
     "@types/jsdom": "^2.0.29",
     "@types/node": "^6.0.48",
-    "@types/react": "~0.14.49",
+    "@types/react": "~15.0.27",
     "@types/react-addons-perf": "~0.14.17",
     "@types/react-addons-test-utils": "^0.14.15",
     "@types/react-dom": "~0.14.18",

--- a/packages/satcheljs/test/createUndoTests.ts
+++ b/packages/satcheljs/test/createUndoTests.ts
@@ -402,7 +402,7 @@ describe('createUndo', () => {
 
         expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
 
-        innerUndo();
+        innerUndo && innerUndo();
 
         expect(array.slice(0)).toEqual([1, 2, 3, 4, 5]);
 


### PR DESCRIPTION
With newer versions of some of our typings dependencies our build was broken.  I had to update TypeScript (to support default type parameters in generics) and some of the typings, so I ended up refreshing a bunch of our dependencies.  I also switched our typings to ~ dependencies to hopefully avoid this sort of break in the future.