### PR TITLE
Update typescript to 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-  "name": "satcheljs",
-  "version": "3.0.0-beta5",
-  "description": "Store implementation for functional reactive flux.",
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "prettier --tab-width 4 --print-width 100 --write --trailing-comma es5 --jsx-bracket-same-line --single-quote",
-      "git add"
-    ]
-  },
-  "scripts": {
-    "precommit": "lint-staged",
-    "clean": "rimraf build lib",
-    "lint": "tslint -t stylish --project tsconfig.json",
-    "build:source": "tsc -p tsconfig.release.json",
-    "watch": "tsc -w -p tsconfig.release.json",
-    "test:unit": "jest",
-    "build": "run-s clean build:source",
-    "start": "run-s clean watch",
-    "test": "run-s lint test:unit",
-    "test:start": "jest --watch"
-  },
-  "devDependencies": {
-    "@types/enzyme": "2.8.1",
-    "@types/jasmine": "~2.5.53",
-    "@types/jsdom": "^11.0.1",
-    "@types/node": "~6.0.78",
-    "@types/react": "15.0.37",
-    "@types/react-addons-perf": "~0.14.18",
-    "@types/react-addons-test-utils": "~0.14.19",
-    "@types/react-dom": "~15.5.1",
-    "enzyme": "^2.9.1",
-    "husky": "~0.14.3",
-    "jasmine": "^2.6.0",
-    "jest": "20.0.4",
-    "lint-staged": "~4.0.1",
-    "npm-run-all": "^4.0.2",
-    "prettier": "~1.5.2",
-    "react-test-renderer": "^15.6.1",
-    "rimraf": "^2.5.4",
-    "tslint": "~5.5.0",
-    "tslint-eslint-rules": "~4.1.1",
-    "tslint-microsoft-contrib": "~5.0.1",
-    "typescript": "~2.3.4"
-  },
-  "dependencies": {
-    "mobx": "~2.6.5",
-    "mobx-react": "~4.0.3",
-    "mobx-react-devtools": "~4.2.10",
-    "react": "^15.6.1",
-    "react-addons-perf": "^15.4.2",
-    "react-dom": "^15.6.1"
-  },
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org"
-  },
-  "license": "MIT"
+    "name": "satcheljs",
+    "version": "3.0.0-beta5",
+    "description": "Store implementation for functional reactive flux.",
+    "lint-staged": {
+        "*.{ts,tsx}": [
+            "prettier --tab-width 4 --print-width 100 --write --trailing-comma es5 --jsx-bracket-same-line --single-quote",
+            "git add"
+        ]
+    },
+    "scripts": {
+        "precommit": "lint-staged",
+        "clean": "rimraf build lib",
+        "lint": "tslint -t stylish --project tsconfig.json",
+        "build:source": "tsc -p tsconfig.release.json",
+        "watch": "tsc -w -p tsconfig.release.json",
+        "test:unit": "jest",
+        "build": "run-s clean build:source",
+        "start": "run-s clean watch",
+        "test": "run-s lint test:unit",
+        "test:start": "jest --watch"
+    },
+    "devDependencies": {
+        "@types/enzyme": "2.8.1",
+        "@types/jasmine": "~2.5.53",
+        "@types/jsdom": "^11.0.1",
+        "@types/node": "~6.0.78",
+        "@types/react": "15.0.37",
+        "@types/react-addons-perf": "~0.14.18",
+        "@types/react-addons-test-utils": "~0.14.19",
+        "@types/react-dom": "~15.5.1",
+        "enzyme": "^2.9.1",
+        "husky": "~0.14.3",
+        "jasmine": "^2.6.0",
+        "jest": "20.0.4",
+        "lint-staged": "~4.0.1",
+        "npm-run-all": "^4.0.2",
+        "prettier": "~1.5.2",
+        "react-test-renderer": "^15.6.1",
+        "rimraf": "^2.5.4",
+        "tslint": "~5.5.0",
+        "tslint-eslint-rules": "~4.1.1",
+        "tslint-microsoft-contrib": "~5.0.1",
+        "typescript": "~2.4.2"
+    },
+    "dependencies": {
+        "mobx": "~2.6.5",
+        "mobx-react": "~4.0.3",
+        "mobx-react-devtools": "~4.2.10",
+        "react": "^15.6.1",
+        "react-addons-perf": "^15.4.2",
+        "react-dom": "^15.6.1"
+    },
+    "main": "lib/index.js",
+    "typings": "lib/index.d.ts",
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org"
+    },
+    "license": "MIT"
 }

--- a/src/interfaces/ActionMessage.ts
+++ b/src/interfaces/ActionMessage.ts
@@ -1,5 +1,6 @@
 interface ActionMessage {
     type?: string;
+    [key: string]: any;
 }
 
 export default ActionMessage;


### PR DESCRIPTION
I had to make a slight change to the `ActionMessage` interface, due to the new stronger validation of weak types in TypeScript 2.4.