### PR TITLE
Change React to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
         "mobx-react": "~4.0.3"
     },
     "peerDependencies": {
-        "react": "^15.4.2",
+        "react": "^15.4.0",
         "react-addons-test-utils": "^15.4.0",
-        "react-dom": "^15.4.2"
+        "react-dom": "^15.4.0"
     },
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
         "test:start": "jest --watch"
     },
     "devDependencies": {
-        "@types/enzyme": "2.8.1",
+        "@types/enzyme": "~2.5.38",
         "@types/jasmine": "~2.5.53",
         "@types/jsdom": "^11.0.1",
         "@types/node": "~6.0.78",
-        "@types/react": "15.0.37",
-        "@types/react-addons-perf": "~0.14.18",
-        "@types/react-addons-test-utils": "~0.14.19",
-        "@types/react-dom": "~15.5.1",
+        "@types/react": "15.0.27",
         "enzyme": "^2.9.1",
         "husky": "~0.14.3",
         "jasmine": "^2.6.0",
@@ -36,7 +33,9 @@
         "lint-staged": "~4.0.1",
         "npm-run-all": "^4.0.2",
         "prettier": "~1.5.2",
-        "react-test-renderer": "^15.6.1",
+        "react": "15.4.2",
+        "react-addons-test-utils": "~15.4.0",
+        "react-dom": "15.4.2",
         "rimraf": "^2.5.4",
         "tslint": "~5.5.0",
         "tslint-eslint-rules": "~4.1.1",
@@ -45,11 +44,12 @@
     },
     "dependencies": {
         "mobx": "~2.6.5",
-        "mobx-react": "~4.0.3",
-        "mobx-react-devtools": "~4.2.10",
-        "react": "^15.6.1",
-        "react-addons-perf": "^15.4.2",
-        "react-dom": "^15.6.1"
+        "mobx-react": "~4.0.3"
+    },
+    "peerDependencies": {
+        "react": "^15.4.2",
+        "react-addons-test-utils": "^15.4.0",
+        "react-dom": "^15.4.2"
     },
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",


### PR DESCRIPTION
We don't want to force consumers to a particular version of React, so this changes it to be a peer (+dev) dependency.  I'm also making the version range a little less restrictive and cleaning up some unused dependencies.