### PR TITLE
Rename several APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,20 @@ class TodoListComponent extends React.Component<any, any> {
 
 ### Implement an action creator
 
-```typescript
-import { actionCreator } from 'satcheljs';
+Note that, as a convenience, Satchel action creators created with the `action` API both *create* and *dispatch* the action.
+This is typically how you want to use action creators.
+If you want to create and dispatch the actions separately you can use the `actionCreator` and `dispatch` APIs.
 
-let addTodo = actionCreator(
+```typescript
+import { action } from 'satcheljs';
+
+let addTodo = action(
     'ADD_TODO',
     (text: string) => ({ text: text })
 );
+
+// This creates and dispatches an ADD_TODO action
+addTodo('Take out trash');
 ```
 
 ### Implement a mutator
@@ -94,30 +101,6 @@ mutator(addTodo, (actionMessage) => {
 };
 ```
 
-### Create and dispatch an action
-
-```typescript
-import { dispatch } from 'satcheljs';
-
-dispatch(addTodo('Take out trash'));
-```
-
-### Bound action creators
-
-Bound action creators create and dispatch the action in one call.
-
-```typescript
-import { boundActionCreator } from 'satcheljs';
-
-let addTodo = boundActionCreator(
-    'ADD_TODO',
-    (text: string) => ({ text: text })
-);
-
-// This creates and dispatches an ADD_TODO action
-addTodo('Take out trash');
-```
-
 ### Orchestrators
 
 Orchestrators are like mutators—they subscribe to actions—but they serve a different purpose.
@@ -127,9 +110,9 @@ Side effects might include making a server call or even dispatching further acti
 The following example shows how an orchestrator can persist a value to a server before updating the store.
 
 ```typescript
-import { boundActionCreator, orchestrator } from 'satcheljs';
+import { action, orchestrator } from 'satcheljs';
 
-let requestAddTodo = boundActionCreator(
+let requestAddTodo = action(
     'REQUEST_ADD_TODO',
     (text: string) => ({ text: text })
 );

--- a/README.md
+++ b/README.md
@@ -140,15 +140,15 @@ orchestrator(requestAddTodo, async (actionMessage) => {
 };
 ```
 
-### Simple mutators and orchestrators
+### mutatorAction and orchestratorAction
 
 In many cases a given action only needs to be handled by one mutator or orchestrator.
-Satchel provides the concept of simple subscribers which encapsulate action creation, dispatch, and handling in one simple function call.
+Satchel provides these utility APIs which encapsulate action creation, dispatch, and handling in one simple function call.
 
 The `addTodo` mutator above could be implemented as follows:
 
 ```typescript
-let addTodo = simpleMutator(
+let addTodo = mutatorAction(
     'ADD_TODO',
     function addTodo(text: string) {
         getStore().todos.push({
@@ -158,10 +158,10 @@ let addTodo = simpleMutator(
     });
 ```
 
-Simple orchestrators can be created similarly:
+An orchestrator can be created similarly:
 
 ```typescript
-let requestAddTodo = simpleOrchestrator(
+let requestAddTodo = orchestratorAction(
     'REQUEST_ADD_TODO',
     async function requestAddTodo(text: string) {
         await addTodoOnServer(actionMessage.text);
@@ -169,8 +169,8 @@ let requestAddTodo = simpleOrchestrator(
     });
 ```
 
-These simple mutators and orchestrators are succinct and easy to write, but they come with a restriction:
-the action creator is not exposed, so no other mutators or orchestrators can subscribe to it.
+This is a succinct and easy way to write mutators and orchestrators, but it comes with a restriction:
+the action creator is not exposed, so no *other* mutators or orchestrators can subscribe to it.
 If an action needs multiple handlers then it must use the full pattern with action creators and handlers implemented separately.
 
 ## License - MIT

--- a/src/actionCreator.ts
+++ b/src/actionCreator.ts
@@ -10,7 +10,7 @@ export function actionCreator<
     return createActionCreator(actionType, target, false);
 }
 
-export function boundActionCreator<
+export function action<
     T extends ActionMessage = {},
     TActionCreator extends ActionCreator<T> = () => T
 >(actionType: string, target?: TActionCreator): TActionCreator {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { default as ActionMessage } from './interfaces/ActionMessage';
 export { default as DispatchFunction } from './interfaces/DispatchFunction';
 export { default as Middleware } from './interfaces/Middleware';
 export { default as Subscriber } from './interfaces/Subscriber';
-export { actionCreator, boundActionCreator } from './actionCreator';
+export { action, actionCreator } from './actionCreator';
 export { default as applyMiddleware } from './applyMiddleware';
 export { default as createStore } from './createStore';
 export { dispatch } from './dispatcher';

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export { dispatch } from './dispatcher';
 export { default as mutator } from './mutator';
 export { default as orchestrator } from './orchestrator';
 export { default as getRootStore } from './getRootStore';
-export { simpleMutator, simpleOrchestrator } from './simpleSubscribers';
+export { mutatorAction, orchestratorAction } from './simpleSubscribers';
 export { useStrict };
 
 // Default to MobX strict mode

--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -1,14 +1,14 @@
 import ActionCreator from './interfaces/ActionCreator';
 import SimpleAction from './interfaces/SimpleAction';
 import Subscriber from './interfaces/Subscriber';
-import { boundActionCreator } from './actionCreator';
+import { action } from './actionCreator';
 import mutator from './mutator';
 import orchestrator from './orchestrator';
 
 export function createSimpleSubscriber(decorator: Function) {
     return function simpleSubscriber<T extends SimpleAction>(actionType: string, target: T): T {
         // Create the action creator
-        let simpleActionCreator = boundActionCreator(actionType, function simpleActionCreator() {
+        let simpleActionCreator = action(actionType, function simpleActionCreator() {
             return {
                 args: arguments,
             };

--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -24,5 +24,5 @@ export function createSimpleSubscriber(decorator: Function) {
     };
 }
 
-export const simpleMutator = createSimpleSubscriber(mutator);
-export const simpleOrchestrator = createSimpleSubscriber(orchestrator);
+export const mutatorAction = createSimpleSubscriber(mutator);
+export const orchestratorAction = createSimpleSubscriber(orchestrator);

--- a/test/actionCreatorTests.ts
+++ b/test/actionCreatorTests.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { actionCreator, boundActionCreator, getPrivateActionId } from '../src/actionCreator';
+import { action, actionCreator, getPrivateActionId } from '../src/actionCreator';
 import * as createActionId from '../src/createActionId';
 import * as dispatcher from '../src/dispatcher';
 
@@ -80,11 +80,11 @@ describe('actionCreator', () => {
     });
 });
 
-describe('boundActionCreator', () => {
+describe('action', () => {
     it('dispatches the action message', () => {
         // Arrange
         let actionMessage = {};
-        const testAction = boundActionCreator('testAction', () => actionMessage);
+        const testAction = action('testAction', () => actionMessage);
         spyOn(dispatcher, 'dispatch');
 
         // Act

--- a/test/endToEndTests.ts
+++ b/test/endToEndTests.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { boundActionCreator } from '../src/actionCreator';
+import { action } from '../src/actionCreator';
 import applyMiddleware from '../src/applyMiddleware';
 import { dispatch } from '../src/dispatcher';
 import mutator from '../src/mutator';
@@ -11,7 +11,7 @@ describe('satcheljs', () => {
         let actualValue;
 
         // Create an action creator
-        let testAction = boundActionCreator('testAction', function testAction(value: string) {
+        let testAction = action('testAction', function testAction(value: string) {
             return {
                 value: value,
             };
@@ -53,7 +53,7 @@ describe('satcheljs', () => {
     it('mutators can modify the store', () => {
         // Arrange
         let store = createStore('testStore', { testProperty: 'testValue' })();
-        let modifyStore = boundActionCreator('modifyStore');
+        let modifyStore = action('modifyStore');
 
         let onModifyStore = mutator(modifyStore, actionMessage => {
             store.testProperty = 'newValue';

--- a/test/endToEndTests.ts
+++ b/test/endToEndTests.ts
@@ -3,7 +3,7 @@ import { boundActionCreator } from '../src/actionCreator';
 import applyMiddleware from '../src/applyMiddleware';
 import { dispatch } from '../src/dispatcher';
 import mutator from '../src/mutator';
-import { simpleMutator } from '../src/simpleSubscribers';
+import { mutatorAction } from '../src/simpleSubscribers';
 import createStore from '../src/createStore';
 
 describe('satcheljs', () => {
@@ -29,12 +29,12 @@ describe('satcheljs', () => {
         expect(actualValue).toBe('test');
     });
 
-    it('simpleMutator dispatches an action and subscribes to it', () => {
+    it('mutatorAction dispatches an action and subscribes to it', () => {
         // Arrange
         let arg1Value;
         let arg2Value;
 
-        let testSimpleMutator = simpleMutator('testSimpleMutator', function testSimpleMutator(
+        let testMutatorAction = mutatorAction('testMutatorAction', function testMutatorAction(
             arg1: string,
             arg2: number
         ) {
@@ -43,7 +43,7 @@ describe('satcheljs', () => {
         });
 
         // Act
-        testSimpleMutator('testValue', 2);
+        testMutatorAction('testValue', 2);
 
         // Assert
         expect(arg1Value).toBe('testValue');

--- a/test/simpleSubscribersTests.ts
+++ b/test/simpleSubscribersTests.ts
@@ -10,7 +10,7 @@ describe('simpleSubscribers', () => {
 
     beforeEach(() => {
         __resetGlobalContext();
-        actionCreatorSpy = spyOn(actionCreator, 'boundActionCreator').and.callThrough();
+        actionCreatorSpy = spyOn(actionCreator, 'action').and.callThrough();
         decoratorSpy = jasmine.createSpy('decoratorSpy');
         simpleSubscriber = createSimpleSubscriber(decoratorSpy);
     });


### PR DESCRIPTION
This renames the following APIs (and updates the README):

`simpleMutator` => `mutatorAction`
`simpleOrchestrator` => `orchestratorAction`
`boundActionCreator` => `action`

For the "simple" APIs, the intent is to make the name a little more specific about what the API is actually creating.  We're renaming `boundActionCreator` because we want the simplest, default kind of action creator to be the one that automatically dispatches.