### PR TITLE
Restrict mutators from dispatching further actions

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -13,6 +13,10 @@ export function subscribe(actionId: string, callback: Subscriber<any>) {
 }
 
 export function dispatch(actionMessage: ActionMessage) {
+    if (getGlobalContext().inMutator) {
+        throw new Error('Mutators cannot dispatch further actions.');
+    }
+
     let dispatchWithMiddleware = getGlobalContext().dispatchWithMiddleware || finalDispatch;
     dispatchWithMiddleware(actionMessage);
 }

--- a/src/globalContext.ts
+++ b/src/globalContext.ts
@@ -14,6 +14,7 @@ export interface GlobalContext {
     nextActionId: number;
     subscriptions: { [key: string]: Subscriber<ActionMessage>[] };
     dispatchWithMiddleware: DispatchFunction;
+    inMutator: boolean;
 
     // Legacy properties
     legacyInDispatch: number;
@@ -38,6 +39,7 @@ export function __resetGlobalContext() {
         nextActionId: 0,
         subscriptions: {},
         dispatchWithMiddleware: null,
+        inMutator: false,
         legacyInDispatch: 0,
         legacyDispatchWithMiddleware: null,
         legacyTestMode: false,

--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -5,6 +5,7 @@ import ActionMessage from './interfaces/ActionMessage';
 import MutatorFunction from './interfaces/MutatorFunction';
 import { getPrivateActionId } from './actionCreator';
 import { subscribe } from './dispatcher';
+import { getGlobalContext } from './globalContext';
 
 export default function mutator<T extends ActionMessage>(
     actionCreator: ActionCreator<T>,
@@ -20,8 +21,13 @@ export default function mutator<T extends ActionMessage>(
 
     // Subscribe to the action
     subscribe(actionId, (actionMessage: T) => {
-        if (wrappedTarget(actionMessage)) {
-            throw new Error('Mutators cannot return a value and cannot be async.');
+        try {
+            getGlobalContext().inMutator = true;
+            if (wrappedTarget(actionMessage)) {
+                throw new Error('Mutators cannot return a value and cannot be async.');
+            }
+        } finally {
+            getGlobalContext().inMutator = false;
         }
     });
 

--- a/test/dispatcherTests.ts
+++ b/test/dispatcherTests.ts
@@ -10,6 +10,7 @@ describe('dispatcher', () => {
         mockGlobalContext = {
             subscriptions: {},
             dispatchWithMiddleware: jasmine.createSpy('dispatchWithMiddleware'),
+            inMutator: false,
         };
 
         spyOn(globalContext, 'getGlobalContext').and.returnValue(mockGlobalContext);
@@ -68,6 +69,16 @@ describe('dispatcher', () => {
 
         // Assert
         expect(callback).toHaveBeenCalled();
+    });
+
+    it('dispatch throws if called within a mutator', () => {
+        // Arrange
+        mockGlobalContext.inMutator = true;
+
+        // Act / Assert
+        expect(() => {
+            dispatcher.dispatch({});
+        }).toThrow();
     });
 
     it('finalDispatch calls all subscribers for a given action', () => {

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -1,9 +1,18 @@
 import 'jasmine';
 import mutator from '../src/mutator';
 import * as dispatcher from '../src/dispatcher';
+import * as globalContext from '../src/globalContext';
 import * as mobx from 'mobx';
 
 describe('mutator', () => {
+    let mockGlobalContext: any;
+
+    beforeEach(() => {
+        mockGlobalContext = { inMutator: false };
+        spyOn(globalContext, 'getGlobalContext').and.returnValue(mockGlobalContext);
+        spyOn(dispatcher, 'subscribe');
+    });
+
     it('throws if the action creator does not have an action ID', () => {
         // Arrange
         let actionCreator: any = {};
@@ -18,7 +27,6 @@ describe('mutator', () => {
         // Arrange
         let actionId = 'testAction';
         let actionCreator: any = { __SATCHELJS_ACTION_ID: actionId };
-        spyOn(dispatcher, 'subscribe');
 
         // Act
         mutator(actionCreator, () => {});
@@ -33,7 +41,6 @@ describe('mutator', () => {
         let callback = () => {};
         let wrappedCallback = () => {};
         let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
-        spyOn(dispatcher, 'subscribe');
         spyOn(mobx, 'action').and.returnValue(wrappedCallback);
 
         // Act
@@ -59,12 +66,28 @@ describe('mutator', () => {
         // Arrange
         let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
         let callback = async () => {};
-        spyOn(dispatcher, 'subscribe');
 
         mutator(actionCreator, callback);
         let subscribedCallback = (dispatcher.subscribe as jasmine.Spy).calls.argsFor(0)[1];
 
         // Act / Assert
         expect(subscribedCallback).toThrow();
+    });
+
+    it('sets the inMutator flag to true for the duration of the mutator callback', () => {
+        // Arrange
+        let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+        let inMutatorValue;
+        let callback = () => {
+            expect(mockGlobalContext.inMutator).toBeTruthy();
+        };
+        mutator(actionCreator, callback);
+
+        // Act
+        let subscribedCallback = (dispatcher.subscribe as jasmine.Spy).calls.argsFor(0)[1];
+        subscribedCallback();
+
+        // Assert
+        expect(mockGlobalContext.inMutator).toBeFalsy();
     });
 });


### PR DESCRIPTION
Mutators should not dispatch further actions.  This change enforces that in the framework.
