### PR TITLE
Change MobX to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "satcheljs",
-    "version": "3.0.1",
+    "version": "3.1.0",
     "description": "Store implementation for functional reactive flux.",
     "lint-staged": {
         "*.{ts,tsx}": [
@@ -31,6 +31,8 @@
         "jasmine": "^2.6.0",
         "jest": "20.0.4",
         "lint-staged": "~4.0.1",
+        "mobx": "~2.6.5",
+        "mobx-react": "~4.0.3",
         "npm-run-all": "^4.0.2",
         "prettier": "~1.5.2",
         "react": "15.4.2",
@@ -42,11 +44,9 @@
         "tslint-microsoft-contrib": "~5.0.1",
         "typescript": "~2.4.2"
     },
-    "dependencies": {
-        "mobx": "~2.6.5",
-        "mobx-react": "~4.0.3"
-    },
     "peerDependencies": {
+        "mobx": "^2.6.5",
+        "mobx-react": "^4.0.3",
         "react": "^15.4.0",
         "react-addons-test-utils": "^15.4.0",
         "react-dom": "^15.4.0"


### PR DESCRIPTION
We've only tested Satchel against MobX 2.X.X, so I left the peer dependency at that version.  However, by making it a peer dep it will just generate a warning and consumers can always use whatever version of MobX they want (at their own risk!)