### PR TITLE
Fixes a subtle bug where mutation on and off flag isn't in the transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "satcheljs",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Store implementation for functional reactive flux.",
     "lint-staged": {
         "*.{ts,tsx}": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { useStrict };
 
 // exporting an alias for orchestrator called "flow"
 export const flow = orchestrator;
+export { orchestrator };
 
 // Default to MobX strict mode
 useStrict(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,13 @@ export { default as applyMiddleware } from './applyMiddleware';
 export { default as createStore } from './createStore';
 export { dispatch } from './dispatcher';
 export { default as mutator } from './mutator';
-export { default as orchestrator } from './orchestrator';
+import { default as orchestrator } from './orchestrator';
 export { default as getRootStore } from './getRootStore';
 export { mutatorAction, orchestratorAction } from './simpleSubscribers';
 export { useStrict };
+
+// exporting an alias for orchestrator called "flow"
+export const flow = orchestrator;
 
 // Default to MobX strict mode
 useStrict(true);

--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -16,20 +16,17 @@ export default function mutator<T extends ActionMessage>(
         throw new Error('Mutators can only subscribe to action creators.');
     }
 
-    // Wrap the callback in a MobX action so it can modify the store
-    let wrappedTarget = action(target);
-
     // Subscribe to the action
-    subscribe(actionId, (actionMessage: T) => {
+    subscribe(actionId, action((actionMessage: T) => {
         try {
             getGlobalContext().inMutator = true;
-            if (wrappedTarget(actionMessage)) {
+            if (target(actionMessage)) {
                 throw new Error('Mutators cannot return a value and cannot be async.');
             }
         } finally {
             getGlobalContext().inMutator = false;
         }
-    });
+    }));
 
     return target;
 }

--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -16,8 +16,8 @@ export default function mutator<T extends ActionMessage>(
         throw new Error('Mutators can only subscribe to action creators.');
     }
 
-    // Subscribe to the action
-    subscribe(actionId, action((actionMessage: T) => {
+    // Wrap the callback in a MobX action so it can modify the store		
+    let wrappedTarget = action((actionMessage: T) => {
         try {
             getGlobalContext().inMutator = true;
             if (target(actionMessage)) {
@@ -26,7 +26,10 @@ export default function mutator<T extends ActionMessage>(
         } finally {
             getGlobalContext().inMutator = false;
         }
-    }));
+    });
+
+    // Subscribe to the action
+    subscribe(actionId, wrappedTarget);
 
     return target;
 }

--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -16,7 +16,7 @@ export default function mutator<T extends ActionMessage>(
         throw new Error('Mutators can only subscribe to action creators.');
     }
 
-    // Wrap the callback in a MobX action so it can modify the store		
+    // Wrap the callback in a MobX action so it can modify the store
     let wrappedTarget = action((actionMessage: T) => {
         try {
             getGlobalContext().inMutator = true;

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -47,7 +47,7 @@ describe('mutator', () => {
         mutator(actionCreator, callback);
 
         // Assert
-        expect(mobx.action).toHaveBeenCalledWith(callback);
+        expect(mobx.action).toHaveBeenCalled();
     });
 
     it('returns the target function', () => {


### PR DESCRIPTION
I'm also adding an alias for orchestrator called "flow" for ease of typing.