### PR TITLE
Relax peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,8 @@
     "peerDependencies": {
         "mobx": "^2.6.5",
         "mobx-react": "^4.0.3",
-        "react": "^15.4.0",
-        "react-addons-test-utils": "^15.4.0",
-        "react-dom": "^15.4.0"
+        "react": ">=15.4.0",
+        "react-dom": ">=15.4.0"
     },
     "main": "lib/index.js",
     "typings": "lib/index.d.ts",


### PR DESCRIPTION
Satchel works just fine with React 16, so I'm relaxing our peer dependencies.