### PR TITLE
Relax strict mode to be compatible with earlier versions of Satchel

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "jasmine": "^2.6.0",
         "jest": "20.0.4",
         "lint-staged": "~4.0.1",
-        "mobx": "^4.3.1",
+        "mobx": "^4.4.0",
         "mobx-react": "^5.2.0",
         "npm-run-all": "^4.0.2",
         "prettier": "~1.5.2",
@@ -45,7 +45,7 @@
         "typescript": "~2.4.2"
     },
     "peerDependencies": {
-        "mobx": "^4.3.1",
+        "mobx": "^4.4.0",
         "mobx-react": "^5.2.0",
         "react": ">=15.4.0",
         "react-dom": ">=15.4.0"

--- a/src/useStrict.ts
+++ b/src/useStrict.ts
@@ -1,5 +1,5 @@
 import { configure } from 'mobx';
 
 export default function useStrict(strictMode: boolean) {
-    configure({ enforceActions: strictMode ? 'strict' : false });
+    configure({ enforceActions: strictMode ? 'observed' : 'never' });
 }

--- a/test/legacy/promise/endToEndTests.ts
+++ b/test/legacy/promise/endToEndTests.ts
@@ -1,4 +1,5 @@
 import 'jasmine';
+import { autorun } from 'mobx';
 import { action, legacyApplyMiddleware } from '../../../src/legacy';
 import { createStore } from '../../../src';
 import { getCurrentAction, promiseMiddleware } from '../../../src/legacy/promise/promiseMiddleware';
@@ -16,6 +17,7 @@ describe('promiseMiddleware', () => {
         legacyApplyMiddleware(promiseMiddleware);
         let store = createStore('testStore', { testValue: 1, currentAction: null })();
         let newValue = 2;
+        observeStore(store);
 
         // Act
         testAction(store, newValue)
@@ -42,6 +44,7 @@ describe('promiseMiddleware', () => {
         legacyApplyMiddleware();
         let store = createStore('testStore', { testValue: null })();
         let newValue = {};
+        observeStore(store);
 
         // Act
         testAction(store, newValue)
@@ -57,3 +60,10 @@ describe('promiseMiddleware', () => {
             });
     });
 });
+
+function observeStore(store: any) {
+    // Strict mode only requires actions if the store is actually observed
+    autorun(() => {
+        store.testValue;
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,9 +1936,9 @@ mobx-react@^5.2.0:
     hoist-non-react-statics "^2.5.0"
     react-lifecycles-compat "^3.0.2"
 
-mobx@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.3.1.tgz#334e5aab4916b1d43f0faf3605a64b1b4b3ccb8d"
+mobx@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-4.4.0.tgz#7fd1b7879cac642988acc0e6e2351e93e3970d12"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
There are actually two things going on here:

1. Update to latest MobX 4.x release.  In this version the [API for turning on strict mode](https://github.com/mobxjs/mobx/blob/gh-pages/docs/refguide/api.md#enforceactions) changed.  (The old values are still accepted, but if you try to use them it prints an annoying warning to the console.)
2. Change our strict mode from `always` to `observed`.  The main place this is an issue is when creating a `new ObservableMap()` in order to initialize a store.  In `always` mode that would have to be done inside an action, which Satchel doesn't give a convenient way to do.  The `observed` mode is the closest match to how strict mode worked in MobX 2.x.