### PR TITLE
throw error if user tries to create a store that already exists

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -5,6 +5,10 @@ let createStoreAction = action('createStore', function createStoreAction(
     key: string,
     initialState: any
 ) {
+    if (getRootStore().get(key)) {
+        throw new Error(`A store named ${key} has already been created.`);
+    }
+
     getRootStore().set(key, initialState);
 });
 

--- a/test/createStoreTests.ts
+++ b/test/createStoreTests.ts
@@ -16,4 +16,21 @@ describe('createStore', () => {
         expect(store).toEqual(initialState);
         expect(getRootStore().get('testStore')).toEqual(initialState);
     });
+
+    it('prevents creating a store with the same name', () => {
+        // Arrange
+        __resetGlobalContext();
+        let initialState = { testProp: 'testValue' };
+
+        let secondaryState = { testProp: 'overwritten' };
+
+        // Act
+        let store = createStore('testStore', initialState)();
+
+        // Assert
+        expect(() => createStore('testStore', secondaryState)()).toThrow(
+            'A store named testStore has already been created.'
+        );
+        expect(getRootStore().get('testStore')).toEqual(initialState);
+    });
 });

--- a/test/createStoreTests.ts
+++ b/test/createStoreTests.ts
@@ -4,9 +4,12 @@ import createStore from '../src/createStore';
 import { __resetGlobalContext } from '../src/globalContext';
 
 describe('createStore', () => {
+    beforeEach(function() {
+        __resetGlobalContext();
+    });
+
     it('creates a subtree under rootStore', () => {
         // Arrange
-        __resetGlobalContext();
         let initialState = { testProp: 'testValue' };
 
         // Act
@@ -19,7 +22,6 @@ describe('createStore', () => {
 
     it('prevents creating a store with the same name', () => {
         // Arrange
-        __resetGlobalContext();
         let initialState = { testProp: 'testValue' };
 
         let secondaryState = { testProp: 'overwritten' };

--- a/test/legacy/promise/endToEndTests.ts
+++ b/test/legacy/promise/endToEndTests.ts
@@ -3,6 +3,7 @@ import { autorun } from 'mobx';
 import { action, legacyApplyMiddleware } from '../../../src/legacy';
 import { createStore } from '../../../src';
 import { getCurrentAction, promiseMiddleware } from '../../../src/legacy/promise/promiseMiddleware';
+import { __resetGlobalContext } from '../../../src/globalContext';
 
 let testAction = action('testAction')(function testAction(store: any, newValue: any) {
     return Promise.resolve(newValue).then(value => {
@@ -12,6 +13,10 @@ let testAction = action('testAction')(function testAction(store: any, newValue: 
 });
 
 describe('promiseMiddleware', () => {
+    beforeEach(function() {
+        __resetGlobalContext();
+    });
+
     it('wraps callbacks in promises when applied', done => {
         // Arrange
         legacyApplyMiddleware(promiseMiddleware);

--- a/test/legacy/react/reactiveTests.tsx
+++ b/test/legacy/react/reactiveTests.tsx
@@ -10,9 +10,15 @@ import { mount, shallow } from 'enzyme';
 import { isObservable } from 'mobx';
 import reactive from '../../../src/legacy/react/reactive';
 
+import { __resetGlobalContext } from '../../../src/globalContext';
+
 let sequenceOfEvents: any[];
 
 describe('reactive decorator', () => {
+    beforeEach(function() {
+        __resetGlobalContext();
+    });
+
     it('observes changes from store', () => {
         let store = createStore('testStore', {
             foo: 'value',

--- a/test/legacy/selectTests.ts
+++ b/test/legacy/selectTests.ts
@@ -4,8 +4,13 @@ import select from '../../src/legacy/select';
 import createStore from '../../src/createStore';
 import { initializeTestMode, resetTestMode } from '../../src/legacy/testMode';
 import { getActionType } from '../../src/legacy/functionInternals';
+import { __resetGlobalContext } from '../../src/globalContext';
 
 describe('select', () => {
+    beforeEach(function() {
+        __resetGlobalContext();
+    });
+
     it('creates a state scoped to subset of state tree', () => {
         let fooStore = createStore('foo', {
             key1: 'value1',


### PR DESCRIPTION
Taking a stab at resolving #96, but it looks like implementing it breaks a lot of the tests that rely on just generating a new store on the fly.

Any guidance on the best way to deal with that? Would you prefer renaming the stores for the tests or adding some cleanup step before those tests run?

Closes #96 