### PR TITLE
Remove orchestratorAction and all references to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ orchestrator(requestAddTodo, async (actionMessage) => {
 };
 ```
 
-### mutatorAction and orchestratorAction
+### mutatorAction
 
-In many cases a given action only needs to be handled by one mutator or orchestrator.
-Satchel provides these utility APIs which encapsulate action creation, dispatch, and handling in one simple function call.
+In many cases a given action only needs to be handled by one mutator.
+Satchel provides this utility API which encapsulates action creation, dispatch, and handling in one simple function call.
 
 The `addTodo` mutator above could be implemented as follows:
 
@@ -141,18 +141,7 @@ let addTodo = mutatorAction(
     });
 ```
 
-An orchestrator can be created similarly:
-
-```typescript
-let requestAddTodo = orchestratorAction(
-    'REQUEST_ADD_TODO',
-    async function requestAddTodo(text: string) {
-        await addTodoOnServer(actionMessage.text);
-        addTodo(actionMessage.text);
-    });
-```
-
-This is a succinct and easy way to write mutators and orchestrators, but it comes with a restriction:
+This is a succinct and easy way to write mutators, but it comes with a restriction:
 the action creator is not exposed, so no *other* mutators or orchestrators can subscribe to it.
 If an action needs multiple handlers then it must use the full pattern with action creators and handlers implemented separately.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { dispatch } from './dispatcher';
 export { default as mutator } from './mutator';
 import { default as orchestrator } from './orchestrator';
 export { default as getRootStore } from './getRootStore';
-export { mutatorAction, orchestratorAction } from './simpleSubscribers';
+export { mutatorAction } from './simpleSubscribers';
 export { useStrict };
 
 // exporting an alias for orchestrator called "flow"

--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -25,4 +25,3 @@ export function createSimpleSubscriber(decorator: Function) {
 }
 
 export const mutatorAction = createSimpleSubscriber(mutator);
-export const orchestratorAction = createSimpleSubscriber(orchestrator);


### PR DESCRIPTION
Given the next release seems to be `4.0.0`, it seems like a perfect time to actually deprecate this as a major breaking change along with the version bump.

Closes #91 