### PR TITLE
Add basic CONTRIBUTING guide for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+1. Fork this repository
+1. Create a `feature/` branch
+1. Make your changes
+1. Add or update tests
+1. Add or update documentation in the `REAMDE.md`
+1. Submit a [Pull Request](https://github.com/Microsoft/satcheljs/pulls)
+  - mention any [Issues](https://github.com/Microsoft/satcheljs/issues) that your
+  PR closes in the body of the PR
+  - Submit your PR as a Draft if you aren't sure and want to discuss or propose
+  changes
+
+## Notes for Contributors
+
+Here is some repository-specific information that contributors might need to know.
+
+### Formatting
+
+This project uses [Prettier](https://github.com/prettier/prettier) to format code
+prior to commiting, so you may notice it making some small adjustments to what you
+wrote.
+
+### CLA
+
+In order to contribute to Satchel, you must first sign the
+[CLA](https://cla.opensource.microsoft.com/Microsoft/satcheljs), which can be found
+at https://cla.opensource.microsoft.com/Microsoft/satcheljs.
+
+If you haven't signed it before submitting a Pull Request, you can access it through
+the `Details` link in the `license/cla` check.
+
+### License
+
+Satchel is licensed under the [MIT License](http://opensource.org/licenses/MIT).


### PR DESCRIPTION
`CONTRIBUTING.md` documents are a recommendation in the `Insights / Community` section of GitHub based on [recommended community standards](https://opensource.guide/).

This gives new contributors a quick overview of what's expected and how to interact with the repository.

I wasn't entirely sure of what you'd want the process outline to be, so I went with what seemed logical.