### PR TITLE
add Editorconfig to help enforce spacing while editing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+
+
+# EditorConfig helps maintain consistent formatting while you work: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,ts}]
+charset = utf-8
+
+# ts files seem to use 4 spaces
+[*.{ts}]
+indent_size = 4
+
+# package.json seems to use 4 spaces
+[{package.json}]
+indent_size = 4
+


### PR DESCRIPTION
There's a lot of inconsistency in the tab size of different file types in this repsository; some files use 2 spaces for a tab and some use 4 spaces for a tab.

[Editorconfig](https://editorconfig.org/) can help with that if contributors add it to their Text Editor or IDE of choice.

This PR adds a simple `.editorconfig` file where I tried to mimic what I was seeing with the different files and filetypes in the repo.