### PR TITLE
chore: update license text to fix GitHub license recognition

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,23 @@
-SatchelJS
-Copyright (c) Microsoft Corporation
-All rights reserved.
 MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Copyright (c) 2016 - present Microsoft Corporation
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The current, incorrect format of the `LICENSE` file prevents GitHub from recognizing the license type which leads to the GitHub API response giving a response without any relevant license info and prevents the GitHub web interface from displaying any license details and information.

The issue can be solved by just putting `MIT License` at the top of the file instead of `SatchelJS`, but it also seemed prudent to update the formatting to match the standard MIT license included in most projects and follow the format of the MIT License `LICENSE` file from other Microsoft projects.

I took the license text in this PR from the [VS Code project's `LICENSE.txt` file](https://github.com/microsoft/vscode/blob/master/LICENSE.txt), and updated the copyright date to match the year of the first commit in this repo.

Here is the GitHub API response for basic license information from `microsoft/satcheljs`:

```json
{
  "data": {
    "repository": {
      "nameWithOwner": "microsoft/satcheljs",
      "licenseInfo": {
        "name": "Other",
        "spdxId": "NOASSERTION",
        "pseudoLicense": true,
        "hidden": true,
        "featured": false,
        "url": "http://choosealicense.com/licenses/other/",
        "description": null
      }
    }
  }
}
```

And here is the response for basic license information for `microsoft/vscode`:

```json
{
  "data": {
    "repository": {
      "nameWithOwner": "microsoft/vscode",
      "licenseInfo": {
        "name": "MIT License",
        "spdxId": "MIT",
        "pseudoLicense": false,
        "hidden": false,
        "featured": true,
        "url": "http://choosealicense.com/licenses/mit/",
        "description": "A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code."
      }
    }
  }
}
```

You can see an example of the extended License information that GitHub shows in it's web interface by looking at the [`LICENSE.txt` file for VS Code](https://github.com/microsoft/vscode/blob/master/LICENSE.txt) and in the included screenshot below.

![license-info](https://user-images.githubusercontent.com/1667415/58752091-d5d4a100-8476-11e9-95aa-46216a82509e.png)