### PR TITLE
Use bind instead of anonymous function to reduce call stack depth in legacy dispatcher

### DIFF
--- a/src/legacy/dispatch.ts
+++ b/src/legacy/dispatch.ts
@@ -12,9 +12,10 @@ export default function dispatch(
 ): void {
     getGlobalContext().legacyInDispatch++;
 
-    mobxAction(actionType ? actionType : '(anonymous action)', () => {
-        dispatchWithMiddleware(action, actionType, args, actionContext);
-    })();
+    mobxAction(
+        actionType ? actionType : '(anonymous action)',
+        dispatchWithMiddleware.bind(null, action, actionType, args, actionContext)
+    )();
 
     getGlobalContext().legacyInDispatch--;
 }

--- a/src/legacy/legacyApplyMiddleware.ts
+++ b/src/legacy/legacyApplyMiddleware.ts
@@ -17,8 +17,7 @@ function applyMiddlewareInternal(
     middleware: LegacyMiddleware,
     next: LegacyDispatchFunction
 ): LegacyDispatchFunction {
-    return (action, actionType, args, actionContext) =>
-        middleware(next, action, actionType, args, actionContext);
+    return middleware.bind(null, next);
 }
 
 export function dispatchWithMiddleware(


### PR DESCRIPTION
Using bound functions instead of anonymous functions helps reduce the depth of the call stack between the point where an action is invoked and the point where the respective method is called, making it easier to read the call stack while debugging.

