### PR TITLE
Prohibit mutator actions from returning values or being async

### DIFF
--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -1,9 +1,6 @@
-import ActionCreator from './interfaces/ActionCreator';
 import SimpleAction from './interfaces/SimpleAction';
-import Subscriber from './interfaces/Subscriber';
 import { action } from './actionCreator';
 import mutator from './mutator';
-import orchestrator from './orchestrator';
 
 export function createSimpleSubscriber(decorator: Function) {
     return function simpleSubscriber<T extends SimpleAction>(actionType: string, target: T): T {

--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -16,7 +16,7 @@ export function createSimpleSubscriber(decorator: Function) {
 
         // Create the subscriber
         decorator(simpleActionCreator, function simpleSubscriberCallback(actionMessage: any) {
-            target.apply(null, actionMessage.args);
+            return target.apply(null, actionMessage.args);
         });
 
         // Return a function that dispatches that action

--- a/test/simpleSubscribersTests.ts
+++ b/test/simpleSubscribersTests.ts
@@ -1,5 +1,5 @@
 import 'jasmine';
-import { createSimpleSubscriber } from '../src/simpleSubscribers';
+import { createSimpleSubscriber, mutatorAction } from '../src/simpleSubscribers';
 import { __resetGlobalContext } from '../src/globalContext';
 import * as actionCreator from '../src/actionCreator';
 
@@ -58,5 +58,14 @@ describe('simpleSubscribers', () => {
 
         // Assert
         expect(callback).toHaveBeenCalledWith(1, 2, 3);
+    });
+
+    it('throws if the target function is async', () => {
+        // Arrange
+        let callback = async () => {};
+        let actionCreator = mutatorAction('testMutator', callback);
+
+        // Act / Assert
+        expect(actionCreator).toThrow();
     });
 });


### PR DESCRIPTION
This addresses #129.  The fix was simple; we already have this check for normal mutators, so the fix is to pass the return value through so that the same check can apply to mutator actions.