### PR TITLE
U/jarmit/fix mutator name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "satcheljs",
-    "version": "4.2.1",
+    "version": "4.2.2",
     "description": "Store implementation for functional reactive flux.",
     "lint-staged": {
         "*.{ts,tsx}": [

--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -17,9 +17,10 @@ export default function mutator<TAction extends ActionMessage, TReturn>(
     }
 
     // Wrap the callback in a MobX action so it can modify the store
-    let wrappedTarget = action(getPrivateActionType(actionCreator), (actionMessage: TAction) => {
+    const actionType = getPrivateActionType(actionCreator);
+    let wrappedTarget = action(actionType, (actionMessage: TAction) => {
         try {
-            getGlobalContext().currentMutator = actionCreator.name;
+            getGlobalContext().currentMutator = actionType;
             target(actionMessage);
         } finally {
             getGlobalContext().currentMutator = null;

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -66,10 +66,10 @@ describe('mutator', () => {
         // Arrange
         let actionCreator: any = {
             __SATCHELJS_ACTION_ID: 'testAction',
-            __SATCHELJS_ACTION_TYPE: 'testName',
+            __SATCHELJS_ACTION_TYPE: 'testActionType',
         };
         let callback = () => {
-            expect(mockGlobalContext.currentMutator).toBe('testName');
+            expect(mockGlobalContext.currentMutator).toBe('testActionType');
         };
         mutator(actionCreator, callback);
 

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -64,9 +64,12 @@ describe('mutator', () => {
 
     it('sets the currentMutator to actionMessage type for the duration of the mutator callback', () => {
         // Arrange
-        let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction', name: 'testName' };
+        let actionCreator: any = {
+            __SATCHELJS_ACTION_ID: 'testAction',
+            __SATCHELJS_ACTION_TYPE: 'testName',
+        };
         let callback = () => {
-            expect(mockGlobalContext.currentMutator).toBe('testAction');
+            expect(mockGlobalContext.currentMutator).toBe('testName');
         };
         mutator(actionCreator, callback);
 

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -66,7 +66,7 @@ describe('mutator', () => {
         // Arrange
         let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction', name: 'testName' };
         let callback = () => {
-            expect(mockGlobalContext.currentMutator).toBe('testName');
+            expect(mockGlobalContext.currentMutator).toBe('testAction');
         };
         mutator(actionCreator, callback);
 


### PR DESCRIPTION
Properly setting the name of the action that the mutator is listening to in the global context property 'currentMutator'.