### PR TITLE
Improve mutatorAction typings

### DIFF
--- a/src/interfaces/SimpleAction.ts
+++ b/src/interfaces/SimpleAction.ts
@@ -1,2 +1,4 @@
-type SimpleAction<TReturn> = void extends TReturn ? (...args: any[]) => TReturn : never;
+type SimpleAction<TFunction extends (...args: any[]) => any> = void extends ReturnType<TFunction>
+    ? TFunction
+    : never;
 export default SimpleAction;

--- a/src/simpleSubscribers.ts
+++ b/src/simpleSubscribers.ts
@@ -3,10 +3,10 @@ import { action } from './actionCreator';
 import mutator from './mutator';
 
 export function createSimpleSubscriber(decorator: Function) {
-    return function simpleSubscriber<TReturn>(
+    return function simpleSubscriber<TFunction extends (...args: any) => any>(
         actionType: string,
-        target: SimpleAction<TReturn>
-    ): SimpleAction<TReturn> {
+        target: TFunction
+    ): SimpleAction<TFunction> {
         // Create the action creator
         let simpleActionCreator = action(actionType, function simpleActionCreator() {
             return {
@@ -20,7 +20,7 @@ export function createSimpleSubscriber(decorator: Function) {
         });
 
         // Return a function that dispatches that action
-        return (simpleActionCreator as any) as SimpleAction<TReturn>;
+        return (simpleActionCreator as any) as SimpleAction<TFunction>;
     };
 }
 

--- a/test/endToEndTests.ts
+++ b/test/endToEndTests.ts
@@ -43,7 +43,7 @@ describe('satcheljs', () => {
         let arg1Value;
         let arg2Value;
 
-        let testMutatorAction = mutatorAction<void>('testMutatorAction', function testMutatorAction(
+        let testMutatorAction = mutatorAction('testMutatorAction', function testMutatorAction(
             arg1: string,
             arg2: number
         ) {


### PR DESCRIPTION
This change improves `mutatorAction` typings to return a function with the same parameters as the input function, rather than simply `(...args: any[]) => void`