### PR TITLE
Use catch instead of finally for browser compatibility

### DIFF
--- a/src/mutator.ts
+++ b/src/mutator.ts
@@ -1,5 +1,4 @@
 import { action } from 'mobx';
-
 import ActionCreator from './interfaces/ActionCreator';
 import ActionMessage from './interfaces/ActionMessage';
 import MutatorFunction from './interfaces/MutatorFunction';
@@ -19,11 +18,14 @@ export default function mutator<TAction extends ActionMessage, TReturn>(
     // Wrap the callback in a MobX action so it can modify the store
     const actionType = getPrivateActionType(actionCreator);
     let wrappedTarget = action(actionType, (actionMessage: TAction) => {
+        const globalContext = getGlobalContext();
         try {
-            getGlobalContext().currentMutator = actionType;
+            globalContext.currentMutator = actionType;
             target(actionMessage);
-        } finally {
-            getGlobalContext().currentMutator = null;
+            globalContext.currentMutator = null;
+        } catch (e) {
+            globalContext.currentMutator = null;
+            throw e;
         }
     });
 

--- a/test/mutatorTests.ts
+++ b/test/mutatorTests.ts
@@ -80,4 +80,27 @@ describe('mutator', () => {
         // Assert
         expect(mockGlobalContext.currentMutator).toBe(null);
     });
+
+    it('sets the currentMutator back to null if error is thrown', () => {
+        // Arrange
+        let actionCreator: any = {
+            __SATCHELJS_ACTION_ID: 'testAction',
+            __SATCHELJS_ACTION_TYPE: 'testActionType',
+        };
+        let callback: any = () => {
+            throw new Error('Error in Mutator');
+        };
+        mutator(actionCreator, callback);
+
+        // Act
+        let subscribedCallback = (dispatcher.subscribe as jasmine.Spy).calls.argsFor(0)[1];
+        try {
+            subscribedCallback();
+        } catch {
+            // no op
+        }
+
+        // Assert
+        expect(mockGlobalContext.currentMutator).toBe(null);
+    });
 });


### PR DESCRIPTION
I am seeing lots of errors in Firefox and IE like `Mutator (MutatorName) may not dispatch action (ActionName)`. And the callstack does not have a mutator in any of its stacks. When I look closer at the error, I see that these errors only happen in Firefox and IE so I think there is a browser compatibility issue where the finally is not getting recognized. I am going to switch over to a try catch instead to see if this fixes the issue