### PR TITLE
Add non-breaking ESM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 .idea/
 .vscode/
 lib/
+lib-esm/
 build/

--- a/package.json
+++ b/package.json
@@ -70,6 +70,31 @@
             "import": "./lib-esm/index.js",
             "default": "./lib/index.js"
         },
+        "./lib/legacy": {
+            "types": "./lib-esm/legacy/index.d.ts",
+            "import": "./lib-esm/legacy/index.js",
+            "default": "./lib/legacy/index.js"
+        },
+        "./lib/legacy/promise": {
+            "types": "./lib-esm/legacy/promise/index.d.ts",
+            "import": "./lib-esm/legacy/promise/index.js",
+            "default": "./lib/legacy/promise/index.js"
+        },
+        "./lib/legacy/react": {
+            "types": "./lib-esm/legacy/react/index.d.ts",
+            "import": "./lib-esm/legacy/react/index.js",
+            "default": "./lib/legacy/react/index.js"
+        },
+        "./lib/legacy/stitch": {
+            "types": "./lib-esm/legacy/stitch/index.d.ts",
+            "import": "./lib-esm/legacy/stitch/index.js",
+            "default": "./lib/legacy/stitch/index.js"
+        },
+        "./lib/legacy/trace": {
+            "types": "./lib-esm/legacy/trace/index.d.ts",
+            "import": "./lib-esm/legacy/trace/index.js",
+            "default": "./lib/legacy/trace/index.js"
+        },
         "./lib/*.js": {
             "types": "./lib-esm/*.d.ts",
             "import": "./lib-esm/*.js",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     },
     "scripts": {
         "precommit": "lint-staged",
-        "clean": "rimraf build lib",
+        "clean": "rimraf build lib lib-esm",
         "lint": "tslint -t stylish --project tsconfig.json",
         "build:source": "tsc -p tsconfig.release.json",
+        "build:source:esm": "tsc -p tsconfig.release-esm.json",
         "watch": "tsc -w -p tsconfig.release.json",
         "test:unit": "jest",
-        "build": "run-s clean build:source",
+        "build": "run-s clean build:source build:source:esm",
         "start": "run-s clean watch",
         "test": "run-s lint build test:unit",
         "test:start": "jest --watch"
@@ -57,9 +58,27 @@
         "react-dom": ">=15.4.0"
     },
     "main": "lib/index.js",
+    "module": "lib-esm/index.js",
     "typings": "lib/index.d.ts",
     "publishConfig": {
         "registry": "https://registry.npmjs.org"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "exports": {
+        ".": {
+            "types": "./lib-esm/index.d.ts",
+            "import": "./lib-esm/index.js",
+            "default": "./lib/index.js"
+        },
+        "./lib/*.js": {
+            "types": "./lib-esm/*.d.ts",
+            "import": "./lib-esm/*.js",
+            "default": "./lib/*.js"
+        },
+        "./lib/*": {
+            "types": "./lib-esm/*.d.ts",
+            "import": "./lib-esm/*.js",
+            "default": "./lib/*.js"
+        }
+    }
 }

--- a/tsconfig.release-esm.json
+++ b/tsconfig.release-esm.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.release.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib-esm",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "removeComments": true,
+    "jsx": "react"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
Currently, the package only ships CommonJS versions of the code. This change adds ESM versions, and an `"exports"` field to `package.json` to direct the imports appropriately.